### PR TITLE
Add tstats-based discovery starters to query workflow

### DIFF
--- a/splunk-sentinel-query-builder/SKILL.md
+++ b/splunk-sentinel-query-builder/SKILL.md
@@ -85,6 +85,8 @@ Return `discovery` instead of a guessed production query when:
 - the field mapping depends on an unknown parser or connector
 - a translation depends on unknown source-table or source-index mapping
 
+Use the Splunk `tstats` and Sentinel discovery starters in [references/query-workflow.md](references/query-workflow.md).
+
 ## Internal data dictionary support
 
 If the user provides an internal URL or excerpt, treat it as the schema source of truth. Extract only:

--- a/splunk-sentinel-query-builder/references/examples-and-troubleshooting.md
+++ b/splunk-sentinel-query-builder/references/examples-and-troubleshooting.md
@@ -65,7 +65,7 @@ Cause:
 Response:
 
 - return `discovery`
-- provide the smallest discovery query that will identify the right index, sourcetype, or table
+- provide the smallest starter from [query-workflow.md](query-workflow.md) (Splunk `tstats` or Sentinel `Usage` / `getschema` patterns) that will identify the right index, sourcetype, or table
 
 ### Problem: internal URL cannot be opened
 

--- a/splunk-sentinel-query-builder/references/query-workflow.md
+++ b/splunk-sentinel-query-builder/references/query-workflow.md
@@ -111,6 +111,58 @@ Do not fake confidence when the query depends on unknown names for:
 If these are missing, provide:
 
 - a short schema discovery checklist
-- a starter query for enumerating likely fields or values
+- a starter query from the discovery sections below
 - a note about whether an internal data dictionary URL would remove the ambiguity
 - no invented production dataset names
+
+## Splunk discovery via tstats
+
+`tstats` reads indexed metadata from `.tsidx` files instead of raw events, so it is the right tool for fast schema discovery. Prefer it over `stats` whenever the goal is to enumerate datasets, hosts, or fields rather than analyze content.
+
+### Index and sourcetype enumeration
+
+List every index and its sourcetypes:
+
+```spl
+| tstats count where index=* by index, sourcetype
+```
+
+Scope to one index to find contributing hosts and sourcetypes:
+
+```spl
+| tstats count where index=YOUR_INDEX by host, sourcetype
+```
+
+### Data model coverage
+
+Use these against the Common Information Model or any accelerated data model:
+
+```spl
+| tstats count from datamodel=YOUR_DATAMODEL by index
+| tstats count from datamodel=Authentication by index, sourcetype
+| tstats count from datamodel=Endpoint where nodename=Endpoint.Processes by index
+```
+
+Add `summariesonly=t` when the data model is accelerated and only summarized results are needed:
+
+```spl
+| tstats summariesonly=t count from datamodel=Authentication by index, sourcetype
+```
+
+### Verify a field is indexed
+
+If a query depends on an unfamiliar field, confirm it is searchable via `tstats` before relying on it:
+
+```spl
+| tstats values(YOUR_FIELD) where index=YOUR_INDEX
+```
+
+An empty result means the field is not indexed and a raw-event search with extraction is required.
+
+### When to return these instead of a production query
+
+Return one of the queries above (and stop) when:
+
+- the exact index or sourcetype is unknown
+- a CIM-backed detection is requested but data model coverage is unclear
+- a KQL-to-SPL translation hinges on which Splunk index receives the source data

--- a/splunk-sentinel-query-builder/references/query-workflow.md
+++ b/splunk-sentinel-query-builder/references/query-workflow.md
@@ -117,7 +117,7 @@ If these are missing, provide:
 
 ## Splunk discovery via tstats
 
-`tstats` reads indexed metadata from `.tsidx` files instead of raw events, so it is the right tool for fast schema discovery. Prefer it over `stats` whenever the goal is to enumerate datasets, hosts, or fields rather than analyze content.
+`tstats` reads indexed metadata, so it is far cheaper than `stats` for enumerating datasets, hosts, or indexed fields.
 
 ### Index and sourcetype enumeration
 
@@ -166,3 +166,64 @@ Return one of the queries above (and stop) when:
 - the exact index or sourcetype is unknown
 - a CIM-backed detection is requested but data model coverage is unclear
 - a KQL-to-SPL translation hinges on which Splunk index receives the source data
+
+## Sentinel discovery via Usage, Heartbeat, and getschema
+
+Log Analytics has no `tstats` analogue, but small metadata tables and the `getschema` operator give the same answers cheaply.
+
+### Workspace and table coverage
+
+`Usage` is a metering table that lists every table that received data, with volume and the connector behind it:
+
+```kql
+Usage
+| where TimeGenerated > ago(7d)
+| summarize TotalGB = sum(Quantity) / 1024 by DataType, Solution
+| sort by TotalGB desc
+```
+
+### Connector and host coverage
+
+`Heartbeat` shows agent-side visibility:
+
+```kql
+Heartbeat
+| where TimeGenerated > ago(24h)
+| summarize LastSeen = max(TimeGenerated) by Computer, OSType, Category
+```
+
+`SentinelHealth` shows connector and analytics-rule status:
+
+```kql
+SentinelHealth
+| where TimeGenerated > ago(7d)
+| summarize count() by SentinelResourceName, Status
+```
+
+### Column and value discovery within a known table
+
+```kql
+TableName | getschema
+TableName | take 5
+```
+
+`getschema` returns column names and types without scanning events. `take 5` is the cheapest way to see real values.
+
+### Cross-table search when the right table is unknown
+
+```kql
+union withsource=Table_ *
+| where TimeGenerated > ago(1h)
+| where SomeField has "value"
+| summarize count() by Table_
+```
+
+Use sparingly — `union *` scans every table. Always constrain `TimeGenerated` first and prefer `Usage` for pure enumeration.
+
+### When to return these instead of a production query
+
+Return one of the queries above (and stop) when:
+
+- the exact table or normalized table is unknown
+- the connector or solution feeding the data is unclear
+- an SPL-to-KQL translation hinges on which Sentinel table receives the source data


### PR DESCRIPTION
## Summary
- Add a `tstats`-based discovery section to `references/query-workflow.md` covering index/sourcetype enumeration, accelerated data model coverage, and indexed-field verification.
- Replace the vague "starter query for enumerating likely fields or values" bullet with a pointer to the new concrete starters, so the skill returns an actionable discovery query when schema is unknown.

## Test plan
- [ ] Read [splunk-sentinel-query-builder/references/query-workflow.md](splunk-sentinel-query-builder/references/query-workflow.md) end-to-end and confirm the new section flows after "When to stop and ask for schema details".
- [ ] Spot-check each `tstats` snippet runs in a Splunk search head (or matches Splunk docs syntax) — `index=*`, `from datamodel=...`, `summariesonly=t`, `values(...)`.
- [ ] Verify the skill's `discovery` output type now has at least one concrete starter for Splunk.

Generated with [Claude Code](https://claude.com/claude-code)
