### PR TITLE
Align claude-opus preferred_prompt with codex/openai

### DIFF
--- a/splunk-sentinel-query-builder/agents/claude-opus.yaml
+++ b/splunk-sentinel-query-builder/agents/claude-opus.yaml
@@ -16,7 +16,7 @@ skill_requirements:
     - "Provide examples and troubleshooting through progressive disclosure."
 
 invocation:
-  preferred_prompt: "Use $splunk-sentinel-query-builder to build, optimize, or translate a Splunk or Sentinel query from my real schema. If dataset names or field mappings are unclear, switch to discovery mode instead of guessing."
+  preferred_prompt: "Use $splunk-sentinel-query-builder to return the smallest useful result for my Splunk or Sentinel task: query, detection, translation, or discovery. Use my exact schema when provided, and switch to discovery mode instead of guessing when datasets are unclear."
   prompt_shape:
     - "Platform: Splunk | Sentinel | Both"
     - "Task: hunt | detection | triage | dashboard | translation | optimization"


### PR DESCRIPTION
## Summary
- Update [splunk-sentinel-query-builder/agents/claude-opus.yaml:19](splunk-sentinel-query-builder/agents/claude-opus.yaml#L19) `preferred_prompt` to match the longer version used by `codex-gpt-5.4.yaml` and `openai.yaml`.
- All three helpers now advertise the same invocation shape, naming every output mode (`query`, `detection`, `translation`, `discovery`) explicitly.

## Test plan
- [ ] Confirm the three prompts match verbatim: `claude-opus.yaml:19`, `codex-gpt-5.4.yaml:19`, `openai.yaml:4`.
- [ ] Re-read each YAML end-to-end to confirm no other fields were touched.

Generated with [Claude Code](https://claude.com/claude-code)
