### PR TITLE
Align Splunk skills with CIM for multi-vendor integrations

### DIFF
--- a/QUERY_SKILL_PLAN.md
+++ b/QUERY_SKILL_PLAN.md
@@ -12,6 +12,7 @@ Create a reusable Codex skill that can:
 - stay concise and predictable for Claude Opus 4.6 and Codex GPT-5.4
 - express clear trigger boundaries, examples, and troubleshooting via progressive disclosure
 - generate Splunk data dictionaries from accessible indexes, sourcetypes, and sampled fields
+- align Splunk guidance with the Common Information Model so multi-vendor sources (Zscaler, Akamai, Microsoft Defender, CrowdStrike, Cloudflare, Proofpoint, web proxies, Cisco, Palo Alto) are queried through shared data models
 
 ## Why this plan
 
@@ -164,6 +165,7 @@ prompts/siem_fun/
     |   `-- openai.yaml
     |-- SKILL.md
     `-- references/
+        |-- cim-vendor-alignment.md
         |-- data-dictionary-integration.md
         |-- examples-and-troubleshooting.md
         |-- model-guidance.md

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The main goal is simple: help the model generate queries that are fast, environm
 
 - a reusable skill for Splunk and Sentinel query generation
 - a Splunk data dictionary builder skill with a local helper script
+- Splunk Common Information Model (CIM) alignment for common vendor sources such as Zscaler, CrowdStrike, Palo Alto, Cisco, Cloudflare, Proofpoint, Akamai, Microsoft Defender, and web proxy infrastructure
 - support for query building, query optimization, and SPL/KQL translation
 - support for internal data dictionaries that describe indexes, sourcetypes, tables, connectors, and fields
 - lower-token guidance optimized for Claude Opus 4.6 and Codex GPT-5.4
@@ -46,6 +47,7 @@ siem_fun/
     |   `-- openai.yaml
     |-- SKILL.md
     `-- references/
+        |-- cim-vendor-alignment.md
         |-- data-dictionary-integration.md
         |-- examples-and-troubleshooting.md
         |-- model-guidance.md
@@ -96,6 +98,28 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-skill-pac
 ## Security
 
 This public repo has GitHub secret scanning, push protection, Dependabot alerts, and Dependabot security updates enabled. Local secret-like files are ignored by `.gitignore`; use `.env.example` as the documented template and keep real credentials in `.env`.
+
+## Splunk CIM and vendor integration coverage
+
+The query builder is aligned with the Splunk Common Information Model so hunts and detections can target shared data models instead of per-vendor sourcetypes. The mapping lives in [splunk-sentinel-query-builder/references/cim-vendor-alignment.md](splunk-sentinel-query-builder/references/cim-vendor-alignment.md), and the data dictionary builder tags recognized vendor sourcetypes with CIM hints and reports installed data models with their acceleration status.
+
+Degree of detail per integration:
+
+| Integration | Coverage level | What is documented |
+| --- | --- | --- |
+| Zscaler (ZIA and ZPA) | Mapped | NSS/LSS sourcetypes, Web / Network_Traffic / Network_Resolution / Network_Sessions models, key CIM fields, feed-configuration caveats |
+| CrowdStrike Falcon | Mapped | Event Streams sourcetype, Endpoint / Malware / Intrusion_Detection models, key fields, FDR field-divergence caveat |
+| Palo Alto Networks (PAN-OS) | Mapped | pan:traffic / pan:threat / pan:globalprotect sourcetypes and their Network_Traffic, Intrusion_Detection, Malware, Web, Authentication models |
+| Cisco (ASA, Firepower/FTD, Umbrella, ISE) | Mapped | Per-product sourcetypes and their Network_Traffic, Intrusion_Detection, Network_Resolution, Authentication, Network_Sessions models |
+| Microsoft Windows Defender / Defender for Endpoint | Mapped | Both the Defender for Endpoint alert feed and the on-host operational log path, with Alerts / Malware / Endpoint models and key fields |
+| Proofpoint (TAP and PPS) | Mapped | TAP and mail gateway sourcetypes with Email / Malware models and key fields |
+| Web proxy infrastructure (ProxySG, Squid, generic) | Mapped | The Web data model as the shared proxy contract, with the canonical field set and cross-proxy query strategy |
+| Cloudflare | Partial | HTTP, firewall, and Gateway DNS log mappings to Web / Intrusion_Detection / Network_Resolution; field availability flagged as dependent on app version and Logpush field selection |
+| Akamai App & API Protector | Mapped | akamai:siem sourcetype with Web / Intrusion_Detection models and key fields |
+| Akamai Noname (API Security) | Outline | Guidance only: no standard CIM add-on exists, so events are treated as Alerts with locally verified field aliases |
+| Other vendors | Procedure | A generic four-step process: find the add-on, check its tags, verify model coverage with tstats, fall back to the dictionary builder |
+
+What "Mapped" means here: typical add-on sourcetypes, target CIM data models, key normalized fields, tstats query patterns, and coverage-verification queries are documented at the query-guidance level. This repo does not ship add-on configurations (props/transforms), detection content, or index names - index naming is deployment-specific and should come from discovery or the data dictionary builder.
 
 ## Quick-start prompt patterns
 
@@ -208,6 +232,7 @@ To get the best results with either model:
 ## Common use cases
 
 - build a Splunk data dictionary from accessible indexes and sourcetypes
+- hunt across multi-vendor sources through one CIM data model query
 - build a new hunt query from a detection idea
 - turn a hunt into a detection
 - optimize a slow Splunk or Sentinel query
@@ -229,6 +254,7 @@ To get the best results with either model:
 - [agents/claude-opus.yaml](splunk-sentinel-query-builder/agents/claude-opus.yaml): companion helper for Claude-style prompting
 - [splunk-sentinel-query-builder/SKILL.md](splunk-sentinel-query-builder/SKILL.md): main skill instructions
 - [references/query-workflow.md](splunk-sentinel-query-builder/references/query-workflow.md): query workflow
+- [references/cim-vendor-alignment.md](splunk-sentinel-query-builder/references/cim-vendor-alignment.md): CIM data models and vendor sourcetype mappings
 - [references/splunk-to-kql-mapping.md](splunk-sentinel-query-builder/references/splunk-to-kql-mapping.md): translation support
 - [references/data-dictionary-integration.md](splunk-sentinel-query-builder/references/data-dictionary-integration.md): internal URL usage
 - [references/examples-and-troubleshooting.md](splunk-sentinel-query-builder/references/examples-and-troubleshooting.md): prompt patterns and failure handling

--- a/examples/golden-prompts.md
+++ b/examples/golden-prompts.md
@@ -125,7 +125,36 @@ Expected output:
 - Maps `src_ip` to `IPAddress`
 - Calls out any assumption about `action=failure` mapping, such as `ResultType != "0"`
 
-## 6. KQL to SPL translation with ambiguous dataset mapping
+## 6. Splunk CIM multi-vendor hunt
+
+Prompt:
+
+```text
+Use $splunk-sentinel-query-builder to hunt blocked web traffic across Zscaler, Cloudflare, and Palo Alto URL filtering.
+Platform: Splunk
+Task: hunt
+Time range: last 24h
+Known datasets: Web data model is accelerated; zscalernss-web, cloudflare:json, and pan:threat are CIM-mapped
+Output style: short
+```
+
+Expected output:
+
+- `Objective`
+- `Query`
+- `Assumptions`
+- Uses one `tstats` query against `datamodel=Web` instead of OR-ing vendor sourcetypes
+- Groups by `sourcetype` or `vendor_product` so per-vendor gaps stay visible
+- Uses `summariesonly=true` only because the prompt confirms acceleration
+- Does not invent index names
+
+Example shape:
+
+```spl
+| tstats summariesonly=true count from datamodel=Web where Web.action="blocked" by Web.src, Web.url, sourcetype
+```
+
+## 7. KQL to SPL translation with ambiguous dataset mapping
 
 Prompt:
 

--- a/examples/golden-prompts.md
+++ b/examples/golden-prompts.md
@@ -143,7 +143,7 @@ Expected output:
 - `Objective`
 - `Query`
 - `Assumptions`
-- Uses one `tstats` query against `datamodel=Web` instead of OR-ing vendor sourcetypes
+- Uses one `tstats` query against `datamodel=Web.Web` instead of OR-ing vendor sourcetypes
 - Groups by `sourcetype` or `vendor_product` so per-vendor gaps stay visible
 - Uses `summariesonly=true` only because the prompt confirms acceleration
 - Does not invent index names
@@ -151,7 +151,7 @@ Expected output:
 Example shape:
 
 ```spl
-| tstats summariesonly=true count from datamodel=Web where Web.action="blocked" by Web.src, Web.url, sourcetype
+| tstats summariesonly=true count from datamodel=Web.Web where Web.action="blocked" by Web.src, Web.url, sourcetype
 ```
 
 ## 7. KQL to SPL translation with ambiguous dataset mapping

--- a/scripts/validate-skill-pack.ps1
+++ b/scripts/validate-skill-pack.ps1
@@ -95,6 +95,7 @@ $requiredFiles = @(
     "splunk-sentinel-query-builder/references/examples-and-troubleshooting.md",
     "splunk-sentinel-query-builder/references/model-guidance.md",
     "splunk-sentinel-query-builder/references/query-workflow.md",
+    "splunk-sentinel-query-builder/references/cim-vendor-alignment.md",
     "splunk-sentinel-query-builder/references/splunk-to-kql-mapping.md",
     "splunk-data-dictionary-builder/SKILL.md",
     "splunk-data-dictionary-builder/agents/openai.yaml",

--- a/splunk-data-dictionary-builder/SKILL.md
+++ b/splunk-data-dictionary-builder/SKILL.md
@@ -30,8 +30,9 @@ Expect these when available:
 1. Confirm the connection method and target scope.
 2. Run [scripts/build_splunk_dictionary.py](scripts/build_splunk_dictionary.py) when local execution is appropriate.
 3. If connection fails, explain whether the failure is auth, TLS, network, or permission related.
-4. Summarize discovered indexes, sourcetypes, fields, and sampling limits.
-5. Save or return structured JSON.
+4. Summarize discovered indexes, sourcetypes, CIM data models, fields, and sampling limits.
+5. Note which sourcetypes carry CIM data model hints so the output can drive CIM-first queries.
+6. Save or return structured JSON.
 
 ## Output Shape
 
@@ -40,9 +41,9 @@ Return or write JSON with:
 - `generated_at`
 - `splunk_base_url`
 - `indexes`
-- `sourcetypes`
-- `fields`
-- `sample_values`
+- `sourcetypes` (rows include `cim_datamodel_hints` for recognized vendor sourcetypes)
+- `cim_datamodels` (installed data models with acceleration status)
+- `field_samples` (per index/sourcetype: `fields` with `sample_values` and `observed_types`)
 - `warnings`
 - `permission_notes`
 

--- a/splunk-data-dictionary-builder/agents/claude-opus.yaml
+++ b/splunk-data-dictionary-builder/agents/claude-opus.yaml
@@ -11,6 +11,7 @@ behavior:
     - "Keep output structured and concise."
     - "Report permission gaps explicitly."
     - "Sample narrowly before expanding scope."
+    - "Tag recognized vendor sourcetypes with likely CIM data models and report installed data model acceleration status."
   stop_conditions:
     - "Stop and explain when authentication fails."
     - "Stop and explain when TLS or network connectivity fails."

--- a/splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml
+++ b/splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml
@@ -11,6 +11,7 @@ behavior:
     - "Keep output structured and concise."
     - "Report permission gaps explicitly."
     - "Sample narrowly before expanding scope."
+    - "Tag recognized vendor sourcetypes with likely CIM data models and report installed data model acceleration status."
   stop_conditions:
     - "Stop and explain when authentication fails."
     - "Stop and explain when TLS or network connectivity fails."

--- a/splunk-data-dictionary-builder/references/workflow.md
+++ b/splunk-data-dictionary-builder/references/workflow.md
@@ -24,7 +24,7 @@ The helper script tags sourcetypes from common add-ons (Zscaler, Akamai, Microso
 
 - a hint means the sourcetype is usually CIM-mapped by its standard add-on
 - actual coverage depends on the add-on being installed and tags being intact
-- confirm with `| tstats count from datamodel=NAME by index, sourcetype` before relying on a data model
+- confirm with `| tstats count from datamodel=MODEL.ROOT_DATASET by index, sourcetype` (for example `datamodel=Web.Web`) before relying on a data model
 - unrecognized sourcetypes may still be CIM-mapped by custom local configuration
 
 ## Permissions Handling

--- a/splunk-data-dictionary-builder/references/workflow.md
+++ b/splunk-data-dictionary-builder/references/workflow.md
@@ -12,9 +12,20 @@ Start cheap and broad, then sample narrowly:
 
 1. List accessible indexes through Splunk REST.
 2. Use `tstats` to enumerate sourcetypes per index.
-3. Sample a small number of events per index/sourcetype.
-4. Collect field names, observed types, and sample values.
-5. Record permission warnings and incomplete coverage.
+3. List installed data models and their acceleration status through Splunk REST.
+4. Sample a small number of events per index/sourcetype.
+5. Collect field names, observed types, and sample values.
+6. Tag recognized vendor sourcetypes with likely CIM data models.
+7. Record permission warnings and incomplete coverage.
+
+## CIM Mapping
+
+The helper script tags sourcetypes from common add-ons (Zscaler, Akamai, Microsoft Defender, CrowdStrike, Cloudflare, Proofpoint, web proxies, Cisco, Palo Alto) with `cim_datamodel_hints` and lists installed data models under `cim_datamodels`. Treat hints as starting points, not proof of coverage:
+
+- a hint means the sourcetype is usually CIM-mapped by its standard add-on
+- actual coverage depends on the add-on being installed and tags being intact
+- confirm with `| tstats count from datamodel=NAME by index, sourcetype` before relying on a data model
+- unrecognized sourcetypes may still be CIM-mapped by custom local configuration
 
 ## Permissions Handling
 
@@ -37,4 +48,4 @@ The dictionary should be useful to an LLM and a human analyst:
 
 ## Query Builder Handoff
 
-Pass the generated JSON or a relevant excerpt to `splunk-sentinel-query-builder` as the internal data dictionary. The query builder should treat exact index, sourcetype, and field names from this output as higher priority than generic assumptions.
+Pass the generated JSON or a relevant excerpt to `splunk-sentinel-query-builder` as the internal data dictionary. The query builder should treat exact index, sourcetype, and field names from this output as higher priority than generic assumptions. When `cim_datamodel_hints` and an accelerated model in `cim_datamodels` agree, the query builder should prefer a CIM `tstats` query over raw sourcetype searches.

--- a/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
+++ b/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
@@ -91,6 +91,62 @@ def entries(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return payload.get("entry", [])
 
 
+# Sourcetype prefixes produced by common Splunkbase add-ons, mapped to the CIM
+# data models they are tagged for. Used as hints only; deployments must verify
+# coverage with: | tstats count from datamodel=NAME by index, sourcetype
+CIM_SOURCETYPE_HINTS: dict[str, list[str]] = {
+    "zscalernss-web": ["Web"],
+    "zscalernss-fw": ["Network_Traffic"],
+    "zscalernss-dns": ["Network_Resolution"],
+    "zscalerlss-zpa-app": ["Network_Sessions", "Web"],
+    "akamai:siem": ["Web", "Intrusion_Detection"],
+    "ms:defender:atp:alerts": ["Alerts", "Malware", "Endpoint"],
+    "crowdstrike:events:sensor": ["Endpoint", "Malware", "Intrusion_Detection"],
+    "cloudflare:json": ["Web", "Intrusion_Detection", "Network_Resolution"],
+    "proofpoint:tap:siem": ["Email", "Malware"],
+    "pps_messagelog": ["Email"],
+    "bluecoat:proxysg:access": ["Web"],
+    "squid:access": ["Web"],
+    "cisco:asa": ["Network_Traffic", "Network_Sessions", "Authentication"],
+    "cisco:estreamer:data": ["Intrusion_Detection", "Network_Traffic"],
+    "cisco:umbrella:dns": ["Network_Resolution"],
+    "cisco:ise:syslog": ["Authentication", "Network_Sessions"],
+    "pan:traffic": ["Network_Traffic"],
+    "pan:threat": ["Intrusion_Detection", "Malware", "Web"],
+    "pan:globalprotect": ["Authentication", "Network_Sessions"],
+}
+
+
+def cim_hints_for_sourcetype(sourcetype: str) -> list[str]:
+    key = sourcetype.lower()
+    for prefix, models in CIM_SOURCETYPE_HINTS.items():
+        if key == prefix or key.startswith(prefix):
+            return models
+    return []
+
+
+def discover_datamodels(client: SplunkClient, warnings: list[str]) -> list[dict[str, Any]]:
+    try:
+        payload = client.get("/services/datamodel/model", {"count": "0"})
+    except RuntimeError as error:
+        warnings.append(str(error))
+        return []
+    models = []
+    for entry in entries(payload):
+        name = entry.get("name")
+        if not name:
+            continue
+        accelerated = False
+        acceleration = entry.get("content", {}).get("acceleration")
+        if isinstance(acceleration, str):
+            try:
+                accelerated = bool(json.loads(acceleration).get("enabled", False))
+            except (ValueError, AttributeError):
+                accelerated = False
+        models.append({"name": name, "accelerated": accelerated})
+    return sorted(models, key=lambda model: model["name"])
+
+
 def discover_indexes(client: SplunkClient, requested: list[str] | None, warnings: list[str]) -> list[str]:
     if requested:
         return requested
@@ -160,7 +216,14 @@ def main() -> int:
 
     indexes = discover_indexes(client, args.indexes, warnings)
     sourcetypes = discover_sourcetypes(client, indexes, args.earliest, warnings)
+    datamodels = discover_datamodels(client, warnings)
     samples = []
+    for row in sourcetypes:
+        sourcetype = row.get("sourcetype")
+        if sourcetype:
+            hints = cim_hints_for_sourcetype(sourcetype)
+            if hints:
+                row["cim_datamodel_hints"] = hints
     for row in sourcetypes[: args.max_sourcetypes]:
         index = row.get("index")
         sourcetype = row.get("sourcetype")
@@ -172,6 +235,7 @@ def main() -> int:
         "splunk_base_url": args.base_url,
         "indexes": indexes,
         "sourcetypes": sourcetypes,
+        "cim_datamodels": datamodels,
         "field_samples": samples,
         "warnings": warnings,
         "permission_notes": [

--- a/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
+++ b/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
@@ -93,7 +93,7 @@ def entries(payload: dict[str, Any]) -> list[dict[str, Any]]:
 
 # Sourcetype prefixes produced by common Splunkbase add-ons, mapped to the CIM
 # data models they are tagged for. Used as hints only; deployments must verify
-# coverage with: | tstats count from datamodel=NAME by index, sourcetype
+# coverage with: | tstats count from datamodel=MODEL.ROOT_DATASET by index, sourcetype
 CIM_SOURCETYPE_HINTS: dict[str, list[str]] = {
     "zscalernss-web": ["Web"],
     "zscalernss-fw": ["Network_Traffic"],

--- a/splunk-sentinel-query-builder/SKILL.md
+++ b/splunk-sentinel-query-builder/SKILL.md
@@ -104,6 +104,7 @@ Prefer dictionary-backed names over guessed names. If the URL cannot be opened, 
 Load only the smallest relevant reference:
 
 - [references/query-workflow.md](references/query-workflow.md) for new hunts, detections, or triage
+- [references/cim-vendor-alignment.md](references/cim-vendor-alignment.md) for CIM data models and vendor sources such as Zscaler, CrowdStrike, Palo Alto, Cisco, Cloudflare, Proofpoint, Akamai, Microsoft Defender, and web proxies
 - [references/splunk-to-kql-mapping.md](references/splunk-to-kql-mapping.md) for translation
 - [references/data-dictionary-integration.md](references/data-dictionary-integration.md) for internal URLs or excerpts
 - [references/examples-and-troubleshooting.md](references/examples-and-troubleshooting.md) for concrete prompt patterns and failure handling
@@ -114,6 +115,7 @@ Load only the smallest relevant reference:
 ### Splunk
 
 - Start with `index=`, `sourcetype=`, `source=`, and time bounds.
+- Prefer CIM data model fields with `tstats` when the source is CIM-mapped; verify coverage first using [references/cim-vendor-alignment.md](references/cim-vendor-alignment.md).
 - Prefer fielded predicates over raw text scans.
 - Delay `rex`, `eval`, and heavy transforms until after filtering.
 - Prefer documented field names over ad hoc extraction.

--- a/splunk-sentinel-query-builder/agents/claude-opus.yaml
+++ b/splunk-sentinel-query-builder/agents/claude-opus.yaml
@@ -48,6 +48,7 @@ behavior:
     - "Do not repeat the user's prompt in long prose."
     - "Use exact dataset and field names when known."
     - "Load only the smallest relevant reference."
+    - "Prefer CIM data model fields for CIM-mapped vendor sources and verify coverage before relying on a data model."
     - "Keep examples and troubleshooting in references rather than the top-level skill file."
   truth_order:
     - "Internal data dictionary URL or excerpt"
@@ -66,6 +67,7 @@ behavior:
 references:
   primary_skill: "../SKILL.md"
   query_workflow: "../references/query-workflow.md"
+  cim_vendor_alignment: "../references/cim-vendor-alignment.md"
   dictionary_integration: "../references/data-dictionary-integration.md"
   examples_and_troubleshooting: "../references/examples-and-troubleshooting.md"
   translation_mapping: "../references/splunk-to-kql-mapping.md"

--- a/splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml
+++ b/splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml
@@ -48,6 +48,7 @@ behavior:
     - "Do not repeat the user's prompt in long prose."
     - "Use exact dataset and field names when known."
     - "Load only the smallest relevant reference."
+    - "Prefer CIM data model fields for CIM-mapped vendor sources and verify coverage before relying on a data model."
     - "Keep examples and troubleshooting in references rather than the top-level skill file."
   truth_order:
     - "Internal data dictionary URL or excerpt"
@@ -66,6 +67,7 @@ behavior:
 references:
   primary_skill: "../SKILL.md"
   query_workflow: "../references/query-workflow.md"
+  cim_vendor_alignment: "../references/cim-vendor-alignment.md"
   dictionary_integration: "../references/data-dictionary-integration.md"
   examples_and_troubleshooting: "../references/examples-and-troubleshooting.md"
   translation_mapping: "../references/splunk-to-kql-mapping.md"

--- a/splunk-sentinel-query-builder/references/cim-vendor-alignment.md
+++ b/splunk-sentinel-query-builder/references/cim-vendor-alignment.md
@@ -19,7 +19,7 @@ Never assume index names. Indexes are deployment-specific; verify with discovery
 
 ## CIM data models that matter here
 
-| Data model | Root node | Core fields |
+| Data model | Root dataset | Core fields |
 | --- | --- | --- |
 | Web | Web | action, src, dest, url, uri_path, http_method, status, http_user_agent, bytes_in, bytes_out, category, user |
 | Network_Traffic | All_Traffic | action, src, dest, dest_port, transport, app, rule, bytes_in, bytes_out, user |
@@ -34,24 +34,26 @@ Never assume index names. Indexes are deployment-specific; verify with discovery
 
 ## CIM query patterns
 
+Qualify the `from` clause as `datamodel=MODEL.ROOT_DATASET`, per the Splunk `tstats` reference. Field references keep the root dataset prefix (`Web.src`, `All_Traffic.dest`). Splunk also accepts the bare model name for single-root models, but the qualified form works everywhere.
+
 Accelerated data model search (fast path):
 
 ```spl
-| tstats summariesonly=true count from datamodel=Web where Web.action="blocked" by Web.src, Web.user, Web.url
+| tstats summariesonly=true count from datamodel=Web.Web where Web.action="blocked" by Web.src, Web.user, Web.url
 ```
 
 ```spl
-| tstats summariesonly=true count from datamodel=Network_Traffic where All_Traffic.dest_port=445 by All_Traffic.src, All_Traffic.dest
+| tstats summariesonly=true count from datamodel=Network_Traffic.All_Traffic where All_Traffic.dest_port=445 by All_Traffic.src, All_Traffic.dest
 ```
 
 ```spl
-| tstats summariesonly=true count from datamodel=Authentication where Authentication.action="failure" by Authentication.user, Authentication.src
+| tstats summariesonly=true count from datamodel=Authentication.Authentication where Authentication.action="failure" by Authentication.user, Authentication.src
 ```
 
-Drop `summariesonly=true` when the model is not accelerated or very recent events matter. Use `nodename` for Endpoint:
+Drop `summariesonly=true` when the model is not accelerated or very recent events matter. The Endpoint model has several root datasets (Processes, Filesystem, Registry, Services); select one in the `from` clause and prefix fields with it:
 
 ```spl
-| tstats summariesonly=true count from datamodel=Endpoint where nodename=Endpoint.Processes by Endpoint.Processes.process_name, Endpoint.Processes.dest
+| tstats summariesonly=true count from datamodel=Endpoint.Processes by Processes.process_name, Processes.dest
 ```
 
 ## Coverage verification
@@ -59,7 +61,7 @@ Drop `summariesonly=true` when the model is not accelerated or very recent event
 Before shipping a CIM-backed query, verify which sourcetypes feed the model:
 
 ```spl
-| tstats count from datamodel=Web by index, sourcetype
+| tstats count from datamodel=Web.Web by index, sourcetype
 ```
 
 Spot-check normalized events:

--- a/splunk-sentinel-query-builder/references/cim-vendor-alignment.md
+++ b/splunk-sentinel-query-builder/references/cim-vendor-alignment.md
@@ -1,0 +1,157 @@
+# Splunk CIM and Vendor Alignment
+
+## Use this file when
+
+- the environment ingests multi-vendor security data into Splunk
+- a hunt or detection should work across products that feed the same CIM data model
+- the user names a vendor (Zscaler, CrowdStrike, Palo Alto, Cisco, Cloudflare, Proofpoint, Akamai, Microsoft Defender, a web proxy) and the query should use normalized fields
+- you must decide between raw sourcetype fields and CIM data model fields
+
+## Core rule
+
+Prefer CIM data model names and fields when the source is CIM-mapped by its add-on. Fall back to raw vendor sourcetypes only when:
+
+- the data model is not populated or not accelerated for the needed window
+- the query needs vendor-specific fields the CIM does not carry
+- coverage verification (below) shows the sourcetype is not mapped
+
+Never assume index names. Indexes are deployment-specific; verify with discovery or the data dictionary builder output.
+
+## CIM data models that matter here
+
+| Data model | Root node | Core fields |
+| --- | --- | --- |
+| Web | Web | action, src, dest, url, uri_path, http_method, status, http_user_agent, bytes_in, bytes_out, category, user |
+| Network_Traffic | All_Traffic | action, src, dest, dest_port, transport, app, rule, bytes_in, bytes_out, user |
+| Network_Resolution | DNS | src, dest, query, reply_code, record_type, answer |
+| Network_Sessions | All_Sessions | action, src_ip, dest_ip, user, duration |
+| Authentication | Authentication | action, app, src, dest, user, signature, authentication_method |
+| Endpoint | Processes, Filesystem, Registry, Services | process, process_name, parent_process_name, process_guid, dest, user, action |
+| Malware | Malware_Attacks | signature, action, file_name, file_path, file_hash, dest, user, vendor_product |
+| Email | All_Email | action, src_user, recipient, subject, file_name, file_hash, url, message_id |
+| Intrusion_Detection | IDS_Attacks | signature, severity, action, src, dest, category, vendor_product |
+| Alerts | Alerts | severity, signature, src, dest, user, vendor_product, description |
+
+## CIM query patterns
+
+Accelerated data model search (fast path):
+
+```spl
+| tstats summariesonly=true count from datamodel=Web where Web.action="blocked" by Web.src, Web.user, Web.url
+```
+
+```spl
+| tstats summariesonly=true count from datamodel=Network_Traffic where All_Traffic.dest_port=445 by All_Traffic.src, All_Traffic.dest
+```
+
+```spl
+| tstats summariesonly=true count from datamodel=Authentication where Authentication.action="failure" by Authentication.user, Authentication.src
+```
+
+Drop `summariesonly=true` when the model is not accelerated or very recent events matter. Use `nodename` for Endpoint:
+
+```spl
+| tstats summariesonly=true count from datamodel=Endpoint where nodename=Endpoint.Processes by Endpoint.Processes.process_name, Endpoint.Processes.dest
+```
+
+## Coverage verification
+
+Before shipping a CIM-backed query, verify which sourcetypes feed the model:
+
+```spl
+| tstats count from datamodel=Web by index, sourcetype
+```
+
+Spot-check normalized events:
+
+```spl
+| datamodel Web search | head 5
+```
+
+Check tagging when a sourcetype is missing from the model:
+
+```spl
+sourcetype=YOUR_SOURCETYPE | head 5 | table tag, eventtype, sourcetype
+```
+
+If a vendor sourcetype is absent from the expected model, return `discovery` with these queries instead of guessing.
+
+## Vendor mappings
+
+Sourcetypes below are the typical names produced by the standard Splunkbase add-on for each product. Real deployments rename indexes and sometimes sourcetypes, so verify with the coverage queries above or with `splunk-data-dictionary-builder` output.
+
+### Zscaler (ZIA and ZPA)
+
+- Add-on: Splunk Add-on for Zscaler (NSS or Cloud NSS feeds).
+- `zscalernss-web` -> Web: action, src, dest, url, http_method, status, user, bytes_in, bytes_out, category.
+- `zscalernss-fw` -> Network_Traffic: action, src, dest, dest_port, transport.
+- `zscalernss-dns` -> Network_Resolution: src, query, reply_code.
+- `zscalerlss-zpa-app` -> Network_Sessions and Web: user, src_ip, dest_ip, application access.
+- Caveat: feed configuration controls which fields are emitted; missing CIM fields usually mean a trimmed NSS feed, not a parsing bug.
+
+### Akamai
+
+- App & API Protector / Kona via the Akamai SIEM Integration add-on: `akamai:siem` -> Web and Intrusion_Detection: action, src, dest, url, signature, severity.
+- Akamai Noname (API Security): no standard CIM-mapped Splunkbase add-on; events usually arrive as custom JSON over HEC. Treat as Alerts (severity, signature, description) plus Web-style fields through local aliases. Confirm local field names with the data dictionary builder before writing detections; this mapping is outline-level only.
+
+### Microsoft Windows Defender / Defender for Endpoint
+
+- Defender for Endpoint alerts via the Splunk Add-on for Microsoft Security: `ms:defender:atp:alerts` -> Alerts, Malware, Endpoint: signature, severity, dest, user, file_name, file_hash.
+- On-host Windows Defender operational log via the Splunk Add-on for Microsoft Windows: `XmlWinEventLog` with source `Microsoft-Windows-Windows Defender/Operational` -> Malware: signature, action, file_name, file_path, dest, user.
+
+### CrowdStrike Falcon
+
+- Add-on: CrowdStrike Falcon Event Streams: `crowdstrike:events:sensor` -> Endpoint, Malware, Intrusion_Detection: process, parent_process_name, file_hash, dest, user, action, severity, signature.
+- Falcon Data Replicator (FDR) feeds Endpoint at higher volume; field names differ from Event Streams, so verify before reusing a query across both.
+
+### Cloudflare
+
+- Logpush to HEC, commonly `cloudflare:json`.
+- HTTP request logs -> Web: src, dest, url (ClientRequestURI alias), status, action, http_user_agent.
+- Firewall events -> Web and Intrusion_Detection: action, signature, src.
+- Gateway DNS -> Network_Resolution: src, query, reply_code.
+- Caveat: CIM compliance depends on the Cloudflare app version and Logpush field selection; treat field availability as partial until verified.
+
+### Proofpoint
+
+- TAP via the Proofpoint TAP modular input: `proofpoint:tap:siem` (message and click events) -> Email and Malware: src_user, recipient, subject, url, file_name, file_hash, action.
+- Proofpoint email gateway (PPS): `pps_messagelog` -> Email: src_user, recipient, subject, action, message_id.
+
+### Web proxy infrastructure (generic)
+
+The Web data model is the canonical contract for every proxy. Once mapped, one tstats pattern covers all of them:
+
+- Symantec ProxySG / Blue Coat: `bluecoat:proxysg:access:*` -> Web.
+- Squid: `squid:access` -> Web.
+- Zscaler web (above), Cloudflare Gateway, and other forward proxies -> Web.
+- Key fields: action, src, dest, url, status, http_method, http_user_agent, bytes_in, bytes_out, category, user.
+
+### Cisco
+
+- ASA via the Splunk Add-on for Cisco ASA: `cisco:asa` -> Network_Traffic, Network_Sessions (VPN), Authentication: src, dest, dest_port, action, transport, user.
+- Firepower / FTD via eStreamer (eNcore) or Cisco Security Cloud: `cisco:estreamer:data` -> Intrusion_Detection and Network_Traffic: signature, severity, src, dest, action.
+- Umbrella via the Cisco Umbrella add-on: `cisco:umbrella:dns` -> Network_Resolution (and Web for proxied traffic): src, query, action, category.
+- ISE: `cisco:ise:syslog` -> Authentication and Network_Sessions: user, src, action, authentication_method.
+
+### Palo Alto Networks (PAN-OS)
+
+- Add-on: Palo Alto Networks Add-on for Splunk (Splunk_TA_paloalto).
+- `pan:traffic` -> Network_Traffic: src, dest, dest_port, action, app, rule, bytes_in, bytes_out.
+- `pan:threat` -> Intrusion_Detection and Malware; URL filtering subtype -> Web: signature, severity, action, url, category.
+- `pan:globalprotect` -> Authentication and Network_Sessions: user, src, action.
+
+### Any other vendor
+
+1. Find the vendor add-on on Splunkbase and note its sourcetypes.
+2. Check which CIM models its tags and eventtypes target.
+3. Run the coverage verification queries above against those models.
+4. If no add-on or mapping exists, build the schema with `splunk-data-dictionary-builder` and query raw sourcetypes with explicit assumptions.
+
+## Cross-vendor query strategy
+
+For hunts that span vendors (for example, blocked web traffic across Zscaler, Cloudflare, and Palo Alto URL filtering):
+
+1. Query the shared data model once instead of OR-ing vendor sourcetypes.
+2. Group by `sourcetype` or `vendor_product` in the output so per-vendor gaps are visible.
+3. State which vendors were verified as feeding the model and which are assumed.
+4. If one vendor is not CIM-mapped, add a second raw-sourcetype query for it rather than weakening the CIM query.

--- a/splunk-sentinel-query-builder/references/query-workflow.md
+++ b/splunk-sentinel-query-builder/references/query-workflow.md
@@ -28,6 +28,7 @@ For Splunk, look for:
 - `sourcetype`
 - `source`
 - common extracted fields
+- CIM data model coverage when the source is a mapped vendor product; see [cim-vendor-alignment.md](cim-vendor-alignment.md)
 
 For Sentinel, look for:
 
@@ -166,6 +167,8 @@ Return one of the queries above (and stop) when:
 - the exact index or sourcetype is unknown
 - a CIM-backed detection is requested but data model coverage is unclear
 - a KQL-to-SPL translation hinges on which Splunk index receives the source data
+
+For vendor-to-CIM mappings (Zscaler, CrowdStrike, Palo Alto, Cisco, Cloudflare, Proofpoint, Akamai, Microsoft Defender, web proxies) and CIM query patterns, read [cim-vendor-alignment.md](cim-vendor-alignment.md).
 
 ## Sentinel discovery via Usage, Heartbeat, and getschema
 

--- a/splunk-sentinel-query-builder/references/query-workflow.md
+++ b/splunk-sentinel-query-builder/references/query-workflow.md
@@ -139,15 +139,15 @@ Scope to one index to find contributing hosts and sourcetypes:
 Use these against the Common Information Model or any accelerated data model:
 
 ```spl
-| tstats count from datamodel=YOUR_DATAMODEL by index
-| tstats count from datamodel=Authentication by index, sourcetype
-| tstats count from datamodel=Endpoint where nodename=Endpoint.Processes by index
+| tstats count from datamodel=YOUR_DATAMODEL.ROOT_DATASET by index
+| tstats count from datamodel=Authentication.Authentication by index, sourcetype
+| tstats count from datamodel=Endpoint.Processes by index
 ```
 
 Add `summariesonly=t` when the data model is accelerated and only summarized results are needed:
 
 ```spl
-| tstats summariesonly=t count from datamodel=Authentication by index, sourcetype
+| tstats summariesonly=t count from datamodel=Authentication.Authentication by index, sourcetype
 ```
 
 ### Verify a field is indexed


### PR DESCRIPTION
## Summary

Aligns the Splunk skills with the Splunk Common Information Model (CIM) so hunts and detections target shared data models across vendor sources instead of per-vendor sourcetypes.

- **New reference** `splunk-sentinel-query-builder/references/cim-vendor-alignment.md`: CIM data model field tables, `tstats` query patterns, coverage-verification queries, and per-vendor sourcetype-to-CIM mappings for Zscaler (ZIA/ZPA), Akamai (App & API Protector and Noname API Security), Microsoft Windows Defender / Defender for Endpoint, CrowdStrike Falcon, Cloudflare, Proofpoint (TAP/PPS), generic web proxy infrastructure (ProxySG, Squid), Cisco (ASA, Firepower/FTD, Umbrella, ISE), Palo Alto (PAN-OS), plus a generic procedure for any other vendor.
- **Query builder skill**: Splunk platform rules and reference loading now prefer CIM data model fields for CIM-mapped sources; helper YAMLs updated in parity.
- **Data dictionary builder**: `build_splunk_dictionary.py` now discovers installed data models with acceleration status (`cim_datamodels`) and tags recognized vendor sourcetypes with `cim_datamodel_hints`; workflow reference documents how to treat the hints; the SKILL.md Output Shape now matches the actual script output.
- **README**: new "Splunk CIM and vendor integration coverage" section with a per-vendor table stating the degree of detail (Mapped / Partial / Outline / Procedure) and an explicit statement of what is and is not covered (no add-on configs, detection content, or index names).
- Golden prompt fixture for a CIM multi-vendor hunt; new reference registered in the validator.

## Coverage depth

All named vendors are documented at the query-guidance level (sourcetypes, target data models, key CIM fields, verification queries). Cloudflare is marked partial (field availability depends on app version and Logpush configuration) and Akamai Noname is outline-only (no standard CIM add-on exists).

## Validation

- `python -m py_compile` passes on the helper script.
- Validator checks (required files, markdown links, helper YAML parity, SKILL.md frontmatter/sections, ASCII-only) replicated locally in Python and pass; `pwsh` is unavailable in this container, so CI runs the authoritative PowerShell validator.

https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC

---
_Generated by [Claude Code](https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC)_