### PR TITLE
Add splunk-enrichment-query-builder skill

### DIFF
--- a/QUERY_SKILL_PLAN.md
+++ b/QUERY_SKILL_PLAN.md
@@ -158,6 +158,17 @@ prompts/siem_fun/
 |   |-- scripts/
 |   |   `-- build_splunk_dictionary.py
 |   `-- SKILL.md
+|-- splunk-enrichment-query-builder/
+|   |-- agents/
+|   |   |-- claude-opus.yaml
+|   |   |-- codex-gpt-5.4.yaml
+|   |   `-- openai.yaml
+|   |-- references/
+|   |   |-- greynoise-integration.md
+|   |   |-- multi-index-patterns.md
+|   |   |-- splunk-cloud-index-management.md
+|   |   `-- splunkbase-app-catalog.md
+|   `-- SKILL.md
 `-- splunk-sentinel-query-builder/
     |-- agents/
     |   |-- claude-opus.yaml

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The main goal is simple: help the model generate queries that are fast, environm
 
 - a reusable skill for Splunk and Sentinel query generation
 - a Splunk data dictionary builder skill with a local helper script that discovers indexes, sourcetypes, fields, installed CIM data models, and live CIM coverage by sourcetype
+- a multi-index enrichment query builder skill with a Splunkbase add-on catalog covering 30+ add-ons, GreyNoise IP enrichment integration, and Splunk Cloud index management guidance
 - Splunk Common Information Model (CIM) alignment for common vendor sources; see the coverage table below for the vendor list and depth
 - support for query building, query optimization, and SPL/KQL translation
 - support for internal data dictionaries that describe indexes, sourcetypes, tables, connectors, and fields
@@ -43,6 +44,17 @@ siem_fun/
 |   |   `-- workflow.md
 |   |-- scripts/
 |   |   `-- build_splunk_dictionary.py
+|   `-- SKILL.md
+|-- splunk-enrichment-query-builder/
+|   |-- agents/
+|   |   |-- claude-opus.yaml
+|   |   |-- codex-gpt-5.4.yaml
+|   |   `-- openai.yaml
+|   |-- references/
+|   |   |-- greynoise-integration.md
+|   |   |-- multi-index-patterns.md
+|   |   |-- splunk-cloud-index-management.md
+|   |   `-- splunkbase-app-catalog.md
 |   `-- SKILL.md
 `-- splunk-sentinel-query-builder/
     |-- agents/
@@ -79,6 +91,12 @@ Use the data dictionary builder first when you do not yet know the local Splunk 
 
 ```text
 Use $splunk-data-dictionary-builder to discover accessible Splunk indexes, sourcetypes, fields, sample values, and CIM data model coverage.
+```
+
+Use the enrichment query builder when the user provides a list of indexes to cover, names a vendor product or Splunkbase add-on, or needs GreyNoise IP enrichment:
+
+```text
+Use $splunk-enrichment-query-builder to build a hunt across index=firewall, index=proxy, and index=endpoint that enriches source IPs with GreyNoise classification.
 ```
 
 ## Local Setup
@@ -254,6 +272,9 @@ To get the best results with either model:
 - translate KQL to SPL
 - use internal schema documentation to avoid bad assumptions
 - generate discovery queries when the environment is unclear
+- build a hunt across multiple user-provided indexes with Splunkbase-aware field knowledge
+- enrich query results with GreyNoise noise and threat-intelligence classification
+- look up Splunkbase add-on sourcetypes and CIM field mappings for a named vendor product
 
 ## Files to read
 
@@ -274,6 +295,11 @@ To get the best results with either model:
 - [references/data-dictionary-integration.md](splunk-sentinel-query-builder/references/data-dictionary-integration.md): internal URL usage
 - [references/examples-and-troubleshooting.md](splunk-sentinel-query-builder/references/examples-and-troubleshooting.md): prompt patterns and failure handling
 - [references/model-guidance.md](splunk-sentinel-query-builder/references/model-guidance.md): model-specific prompt tuning
+- [splunk-enrichment-query-builder/SKILL.md](splunk-enrichment-query-builder/SKILL.md): multi-index enrichment skill instructions
+- [splunk-enrichment-query-builder/references/splunkbase-app-catalog.md](splunk-enrichment-query-builder/references/splunkbase-app-catalog.md): Splunkbase add-on sourcetypes, key fields, and CIM mappings
+- [splunk-enrichment-query-builder/references/multi-index-patterns.md](splunk-enrichment-query-builder/references/multi-index-patterns.md): SPL patterns for multi-index search and iteration
+- [splunk-enrichment-query-builder/references/greynoise-integration.md](splunk-enrichment-query-builder/references/greynoise-integration.md): GreyNoise SPL commands, lookups, and enrichment patterns
+- [splunk-enrichment-query-builder/references/splunk-cloud-index-management.md](splunk-enrichment-query-builder/references/splunk-cloud-index-management.md): Splunk Cloud index properties, stack types, and REST API
 
 ## Practical note
 

--- a/scripts/validate-skill-pack.ps1
+++ b/scripts/validate-skill-pack.ps1
@@ -102,7 +102,15 @@ $requiredFiles = @(
     "splunk-data-dictionary-builder/agents/claude-opus.yaml",
     "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml",
     "splunk-data-dictionary-builder/references/workflow.md",
-    "splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py"
+    "splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py",
+    "splunk-enrichment-query-builder/SKILL.md",
+    "splunk-enrichment-query-builder/agents/openai.yaml",
+    "splunk-enrichment-query-builder/agents/claude-opus.yaml",
+    "splunk-enrichment-query-builder/agents/codex-gpt-5.4.yaml",
+    "splunk-enrichment-query-builder/references/splunkbase-app-catalog.md",
+    "splunk-enrichment-query-builder/references/multi-index-patterns.md",
+    "splunk-enrichment-query-builder/references/greynoise-integration.md",
+    "splunk-enrichment-query-builder/references/splunk-cloud-index-management.md"
 )
 
 foreach ($file in $requiredFiles) {
@@ -129,7 +137,7 @@ foreach ($file in $trackedFiles) {
     }
 }
 
-foreach ($skill in @("splunk-sentinel-query-builder/SKILL.md", "splunk-data-dictionary-builder/SKILL.md")) {
+foreach ($skill in @("splunk-sentinel-query-builder/SKILL.md", "splunk-data-dictionary-builder/SKILL.md", "splunk-enrichment-query-builder/SKILL.md")) {
     Assert-Contains $skill '(?s)^---\s+name:\s+[-a-z0-9]+\s+description:\s+.+?\s+---' "valid skill frontmatter"
     Assert-Contains $skill '## Important' "top-level Important section"
     Assert-Contains $skill '## Inputs' "Inputs section"
@@ -149,9 +157,17 @@ foreach ($key in @("interface:", "display_name:", "short_description:", "default
     }
 }
 
+$enrichmentOpenai = Read-Text "splunk-enrichment-query-builder/agents/openai.yaml"
+foreach ($key in @("interface:", "display_name:", "short_description:", "default_prompt:", "policy:", "allow_implicit_invocation: false")) {
+    if ($enrichmentOpenai -notmatch [regex]::Escape($key)) {
+        Add-Issue "splunk-enrichment-query-builder/agents/openai.yaml is missing $key"
+    }
+}
+
 foreach ($helperPair in @(
     @("splunk-sentinel-query-builder/agents/claude-opus.yaml", "splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml"),
-    @("splunk-data-dictionary-builder/agents/claude-opus.yaml", "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml")
+    @("splunk-data-dictionary-builder/agents/claude-opus.yaml", "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml"),
+    @("splunk-enrichment-query-builder/agents/claude-opus.yaml", "splunk-enrichment-query-builder/agents/codex-gpt-5.4.yaml")
 )) {
     $claude = Read-Text $helperPair[0]
     $codex = Read-Text $helperPair[1]

--- a/splunk-enrichment-query-builder/SKILL.md
+++ b/splunk-enrichment-query-builder/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: splunk-enrichment-query-builder
+description: Build Splunk queries that span multiple user-provided indexes with Splunkbase add-on sourcetype and field knowledge, and optionally enrich results with GreyNoise threat intelligence. Use when the user provides a list of indexes, names a Splunkbase add-on or vendor product, or requests IP-based enrichment in a Splunk environment. Do not use for Sentinel/KQL queries, data dictionary generation, or single-index queries where the schema is fully known.
+---
+
+# Splunk Enrichment Query Builder
+
+Use this skill to build multi-index Splunk queries grounded in Splunkbase add-on field schemas and enriched with GreyNoise context when IP addresses are present.
+
+## Important
+
+- Never invent index names, sourcetypes, or GreyNoise field names. If the schema is uncertain, return a discovery query from [multi-index-patterns.md](references/multi-index-patterns.md) and stop.
+- Prefer `index IN (...)` over `OR`-chained index filters (Splunk 8.2+).
+- GreyNoise enrichment requires the GreyNoise App for Splunk. Fall back to the `greynoise_full` lookup join when the custom commands are unavailable.
+- Splunk Cloud imposes index naming and management constraints that differ from self-managed deployments; see [splunk-cloud-index-management.md](references/splunk-cloud-index-management.md).
+- Never ask the user to paste API tokens, passwords, or Splunk credentials into chat.
+
+## Inputs
+
+Required:
+- `indexes`: one or more index names provided by the user
+- `task`: hunt | detection | triage | enrichment | discovery
+- `objective`: what to find, detect, or enrich
+
+Optional but recommended:
+- `sourcetypes`: known sourcetypes within the provided indexes
+- `greynoise`: yes | no (default: include when IP fields are present)
+- `time_range`: earliest=-24h | -7d | etc.
+- `output_style`: short | full
+- `environment`: splunk-cloud | self-managed
+- `data_dictionary`: URL or pasted excerpt from an internal data dictionary
+
+## Workflow
+
+### 1. Classify each index
+
+For each provided index name:
+1. If sourcetypes are unknown, return the enumeration query from [multi-index-patterns.md](references/multi-index-patterns.md) and stop before writing a production query.
+2. If sourcetypes are known or can be inferred from the index name, look them up in [splunkbase-app-catalog.md](references/splunkbase-app-catalog.md) to identify CIM model mappings and key fields.
+3. When the environment is Splunk Cloud, check index naming and REST constraints in [splunk-cloud-index-management.md](references/splunk-cloud-index-management.md).
+
+### 2. Build the multi-index query
+
+Use patterns from [multi-index-patterns.md](references/multi-index-patterns.md):
+- Prefer `index IN (idx1, idx2, ...)` for simple multi-index event searches.
+- Use per-index sourcetype filters when schemas differ significantly across indexes.
+- Prefer CIM data model queries via `tstats` when multiple source types feed the same model.
+
+### 3. Enrich with GreyNoise (when IP fields are present)
+
+When the query output contains IP fields (src, dest, src_ip, dest_ip, ClientIP, or equivalent), add GreyNoise enrichment per [greynoise-integration.md](references/greynoise-integration.md):
+- Use `gnenrich` when the GreyNoise App is installed.
+- Fall back to a `lookup greynoise_full` join when the custom command is unavailable.
+- Include a RIOT filter to remove known-benign infrastructure.
+
+### 4. Shape the output
+
+Default output:
+1. Objective
+2. Query
+3. Why efficient
+4. Assumptions
+5. Enrichment notes (if GreyNoise added)
+6. Tuning
+7. Validate
+
+Short output (`output_style: short`):
+1. Objective
+2. Query
+3. Assumptions
+
+## References
+
+- [splunkbase-app-catalog.md](references/splunkbase-app-catalog.md): Splunkbase add-on sourcetypes, key fields, and CIM data model mappings
+- [multi-index-patterns.md](references/multi-index-patterns.md): SPL patterns for multi-index search, discovery, and iteration
+- [greynoise-integration.md](references/greynoise-integration.md): GreyNoise SPL commands, lookup files, field reference, and enrichment patterns
+- [splunk-cloud-index-management.md](references/splunk-cloud-index-management.md): Splunk Cloud index properties, naming constraints, REST API, and stack types

--- a/splunk-enrichment-query-builder/agents/claude-opus.yaml
+++ b/splunk-enrichment-query-builder/agents/claude-opus.yaml
@@ -1,0 +1,72 @@
+helper:
+  model_family: "claude-opus"
+  target_model: "Claude Opus 4.6"
+  purpose: "Companion helper for using the Splunk enrichment query builder skill with Claude-style prompting and Anthropic-aligned skill structure."
+
+skill_requirements:
+  description_rules:
+    - "State what the skill does."
+    - "State when to use it."
+    - "State when not to use it when boundaries matter."
+    - "Keep the description concise and trigger-oriented."
+  instruction_rules:
+    - "Put critical instructions near the top."
+    - "Use imperative steps with explicit inputs and outputs."
+    - "Keep SKILL.md focused and move detail to references."
+    - "Provide examples and troubleshooting through progressive disclosure."
+
+invocation:
+  preferred_prompt: "Use $splunk-enrichment-query-builder to build the smallest useful Splunk query for the provided indexes. Use my exact sourcetypes and fields when given. Add GreyNoise enrichment when IP fields are present. Switch to discovery mode when the schema is unclear."
+  prompt_shape:
+    - "Platform: Splunk"
+    - "Task: hunt | detection | triage | enrichment | discovery"
+    - "Objective: what to find, detect, or enrich"
+    - "Time range: last 1h | 24h | 7d"
+    - "Indexes: list of index names"
+    - "Sourcetypes: known sourcetypes within those indexes (optional)"
+    - "GreyNoise: yes | no"
+    - "Output style: short | full"
+
+response_contract:
+  default_sections:
+    - "Objective"
+    - "Query"
+    - "Why efficient"
+    - "Assumptions"
+    - "Enrichment notes"
+    - "Tuning"
+    - "Validate"
+  short_sections:
+    - "Objective"
+    - "Query"
+    - "Assumptions"
+
+behavior:
+  token_rules:
+    - "Keep the answer query-first and highly structured."
+    - "Do not explain basic SPL syntax unless asked."
+    - "Do not repeat the user's prompt in long prose."
+    - "Use exact dataset and field names when known."
+    - "Load only the smallest relevant reference."
+    - "Prefer CIM data model fields for CIM-mapped vendor sources and verify coverage before relying on a data model."
+    - "Keep examples and troubleshooting in references rather than the top-level skill file."
+  truth_order:
+    - "Internal data dictionary URL or excerpt"
+    - "Explicit user-provided dataset and field names"
+    - "Repo references"
+    - "Discovery query"
+  stop_conditions:
+    - "Return discovery mode when the exact dataset name is missing."
+    - "Return discovery mode when field mapping depends on an unknown parser or connector."
+    - "Return discovery mode when translation depends on unknown source-table or source-index mapping."
+  trigger_tuning:
+    - "If the skill undertriggers, add more trigger detail to the description."
+    - "If the skill overtriggers, add negative triggers and tighten scope."
+    - "If execution is inconsistent, improve instructions and error handling."
+
+references:
+  primary_skill: "../SKILL.md"
+  splunkbase_catalog: "../references/splunkbase-app-catalog.md"
+  multi_index_patterns: "../references/multi-index-patterns.md"
+  greynoise_integration: "../references/greynoise-integration.md"
+  cloud_index_management: "../references/splunk-cloud-index-management.md"

--- a/splunk-enrichment-query-builder/agents/codex-gpt-5.4.yaml
+++ b/splunk-enrichment-query-builder/agents/codex-gpt-5.4.yaml
@@ -1,0 +1,72 @@
+helper:
+  model_family: "codex"
+  target_model: "GPT-5.4"
+  purpose: "Companion helper for using the Splunk enrichment query builder skill with Codex and OpenAI-style prompting."
+
+skill_requirements:
+  description_rules:
+    - "State what the skill does."
+    - "State when to use it."
+    - "State when not to use it when boundaries matter."
+    - "Keep the description concise and trigger-oriented."
+  instruction_rules:
+    - "Put critical instructions near the top."
+    - "Use imperative steps with explicit inputs and outputs."
+    - "Keep SKILL.md focused and move detail to references."
+    - "Provide examples and troubleshooting through progressive disclosure."
+
+invocation:
+  preferred_prompt: "Use $splunk-enrichment-query-builder to build the smallest useful Splunk query for the provided indexes. Use my exact sourcetypes and fields when given. Add GreyNoise enrichment when IP fields are present. Switch to discovery mode when the schema is unclear."
+  prompt_shape:
+    - "Platform: Splunk"
+    - "Task: hunt | detection | triage | enrichment | discovery"
+    - "Objective: what to find, detect, or enrich"
+    - "Time range: last 1h | 24h | 7d"
+    - "Indexes: list of index names"
+    - "Sourcetypes: known sourcetypes within those indexes (optional)"
+    - "GreyNoise: yes | no"
+    - "Output style: short | full"
+
+response_contract:
+  default_sections:
+    - "Objective"
+    - "Query"
+    - "Why efficient"
+    - "Assumptions"
+    - "Enrichment notes"
+    - "Tuning"
+    - "Validate"
+  short_sections:
+    - "Objective"
+    - "Query"
+    - "Assumptions"
+
+behavior:
+  token_rules:
+    - "Keep the answer query-first and highly structured."
+    - "Do not explain basic SPL syntax unless asked."
+    - "Do not repeat the user's prompt in long prose."
+    - "Use exact dataset and field names when known."
+    - "Load only the smallest relevant reference."
+    - "Prefer CIM data model fields for CIM-mapped vendor sources and verify coverage before relying on a data model."
+    - "Keep examples and troubleshooting in references rather than the top-level skill file."
+  truth_order:
+    - "Internal data dictionary URL or excerpt"
+    - "Explicit user-provided dataset and field names"
+    - "Repo references"
+    - "Discovery query"
+  stop_conditions:
+    - "Return discovery mode when the exact dataset name is missing."
+    - "Return discovery mode when field mapping depends on an unknown parser or connector."
+    - "Return discovery mode when translation depends on unknown source-table or source-index mapping."
+  packaging_rules:
+    - "Keep agents/openai.yaml schema-compliant and minimal for Codex tooling."
+    - "Put richer repo-local OpenAI guidance in this companion helper rather than inventing unsupported openai.yaml keys."
+    - "Align default prompt behavior between this file and openai.yaml."
+
+references:
+  primary_skill: "../SKILL.md"
+  splunkbase_catalog: "../references/splunkbase-app-catalog.md"
+  multi_index_patterns: "../references/multi-index-patterns.md"
+  greynoise_integration: "../references/greynoise-integration.md"
+  cloud_index_management: "../references/splunk-cloud-index-management.md"

--- a/splunk-enrichment-query-builder/agents/openai.yaml
+++ b/splunk-enrichment-query-builder/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Splunk Enrichment Query Builder"
+  short_description: "Build Splunk queries across multiple indexes with Splunkbase add-on field knowledge and GreyNoise IP enrichment"
+  default_prompt: "Use $splunk-enrichment-query-builder to build the smallest useful Splunk query for the provided indexes. Use my exact sourcetypes and fields when given. Add GreyNoise enrichment when IP fields are present. Switch to discovery mode when the schema is unclear."
+
+policy:
+  allow_implicit_invocation: false

--- a/splunk-enrichment-query-builder/references/greynoise-integration.md
+++ b/splunk-enrichment-query-builder/references/greynoise-integration.md
@@ -1,0 +1,194 @@
+# GreyNoise Splunk Integration
+
+## Use this file when
+
+- a query surfaces IP fields (src, dest, src_ip, dest_ip, ClientIP, or equivalent) and enrichment with internet-noise context reduces false positives
+- you need to filter background scanner traffic from an investigation
+- the user asks for GreyNoise-enriched detections, dashboards, or feeds
+- you need GreyNoise field names, SPL commands, or lookup table names
+
+## GreyNoise concepts
+
+| Term | Meaning |
+| --- | --- |
+| Noise | An IP observed actively scanning or crawling the public internet. A `noise=true` IP is likely an opportunistic scanner, not a targeted threat. |
+| RIOT (Rule It Out) | IPs belonging to known-benign services: Google, Cloudflare, AWS, Akamai, and similar web-scale platforms. Filter these first to reduce alert volume. |
+| Classification | `malicious`: associated with known attack tooling or campaigns. `benign`: a recognized scanner or service with no attack history. `unknown`: not observed in GreyNoise data. |
+| Tags | Behavioral labels such as `SSH Scanner`, `Tor Exit Node`, `Mirai`, `Log4Shell Exploit`, `VNC Scanner`, `Web Crawler`. |
+
+## Installation
+
+Install the **GreyNoise App and Add-On for Splunk** from Splunkbase. The app:
+- Registers custom SPL commands (`gnlookup`, `gnenrich`, `gnmeta`)
+- Ships two synced CSV lookup files (`greynoise_full.csv`, `greynoise_riot.csv`)
+- Includes pre-built intelligence dashboards
+- Requires a valid GreyNoise API key configured under the app setup page
+
+## Custom SPL commands
+
+### `gnlookup` - single IP lookup
+
+Useful for investigating one IP ad hoc:
+
+```spl
+| gnlookup ip="203.0.113.42"
+```
+
+Returns one row with all GreyNoise context fields.
+
+### `gnenrich` - bulk IP enrichment across a dataset
+
+Enrich a field containing IP addresses across all rows of the current pipeline. Batches API calls automatically:
+
+```spl
+index=firewall sourcetype=cisco:asa earliest=-24h
+| stats count by src
+| gnenrich field=src
+| where noise=true OR classification="malicious"
+| sort - count
+```
+
+`gnenrich` requires a configured API key and consumes GreyNoise API quota. Pre-filter to a smaller IP list before enrichment on large result sets.
+
+### `gnmeta` - account metadata
+
+Returns API quota information and account context; useful for troubleshooting:
+
+```spl
+| gnmeta
+```
+
+## Lookup-based enrichment (no custom commands required)
+
+Use the scheduled lookup files when the GreyNoise App is installed but the custom commands are unavailable, or for scheduled saved searches where API quota must be conserved.
+
+### `greynoise_full.csv` - active noise and malicious IPs
+
+```spl
+index=firewall sourcetype=cisco:asa earliest=-24h
+| stats count by src
+| lookup greynoise_full ip AS src OUTPUT classification, noise, riot, tags, name, last_seen
+| where noise=true OR classification="malicious"
+| sort - count
+```
+
+### `greynoise_riot.csv` - known-benign service IPs
+
+Use RIOT as a pre-filter to remove large-platform traffic before investigating:
+
+```spl
+index=proxy sourcetype=bluecoat:proxysg:access:kv earliest=-24h
+| stats count by dest
+| lookup greynoise_riot ip AS dest OUTPUT riot, name AS riot_service
+| where isnull(riot) OR riot=false
+| sort - count
+```
+
+## GreyNoise field reference
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `ip` | string | The IP address looked up |
+| `noise` | boolean | True if the IP is actively scanning the public internet |
+| `riot` | boolean | True if the IP belongs to a known-benign service |
+| `classification` | string | `malicious`, `benign`, or `unknown` |
+| `name` | string | Organization or actor name |
+| `tags` | string | Comma-separated behavioral tags |
+| `first_seen` | date | First date the IP was observed by GreyNoise |
+| `last_seen` | date | Most recent observation date |
+| `country` | string | Country of origin (full name) |
+| `country_code` | string | ISO 3166-1 alpha-2 country code |
+| `city` | string | City of origin |
+| `organization` | string | ASN organization name |
+| `asn` | string | Autonomous system number (e.g., AS15169) |
+| `actor` | string | Named threat actor if known |
+| `cve` | string | Associated CVE identifiers |
+
+## Common enrichment patterns
+
+### Noise filter: remove background scanners from a firewall investigation
+
+```spl
+index=firewall sourcetype=cisco:asa action=blocked earliest=-24h
+| stats count by src
+| lookup greynoise_full ip AS src OUTPUT noise, classification, tags
+| where noise=false AND classification!="benign"
+| sort - count
+| table src, count, classification, tags
+```
+
+### Malicious IP detection: connections to or from known-malicious IPs
+
+```spl
+index IN (firewall, proxy) earliest=-24h
+| eval ip_field=coalesce(src, src_ip, ClientIP)
+| stats count by ip_field, index, sourcetype
+| lookup greynoise_full ip AS ip_field OUTPUT classification, actor, tags, last_seen
+| where classification="malicious"
+| table ip_field, count, index, sourcetype, actor, tags, last_seen
+```
+
+### RIOT enrichment: identify traffic to major CDNs and SaaS platforms
+
+```spl
+index=proxy sourcetype=bluecoat:proxysg:access:kv earliest=-24h
+| stats count by dest
+| lookup greynoise_riot ip AS dest OUTPUT riot, name AS riot_service
+| where riot=true
+| stats sum(count) AS total_hits by riot_service
+| sort - total_hits
+```
+
+### Emerging threats: IPs first seen by GreyNoise within the last 24 hours
+
+```spl
+| inputlookup greynoise_full
+| where strptime(first_seen, "%Y-%m-%d") > relative_time(now(), "-24h@h")
+| where classification="malicious"
+| table ip, tags, actor, country, first_seen
+```
+
+### Cross-reference with internal firewall permit logs
+
+```spl
+index=firewall sourcetype=cisco:asa action=permitted earliest=-24h
+| stats count by src
+| lookup greynoise_full ip AS src OUTPUT classification, noise, riot, tags, actor, last_seen
+| where classification="malicious" OR (noise=true AND riot=false)
+| table src, count, classification, noise, tags, actor, last_seen
+```
+
+### Multi-index IP enrichment
+
+When the user provides multiple indexes that each surface IP fields:
+
+```spl
+index IN (firewall, proxy, endpoint) earliest=-24h
+| eval ip_field=coalesce(src, src_ip, dest, dest_ip)
+| where isnotnull(ip_field) AND match(ip_field, "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+| stats count by ip_field, index, sourcetype
+| lookup greynoise_full ip AS ip_field OUTPUT classification, noise, riot, tags, actor
+| where classification="malicious" OR noise=true
+| sort - count
+| table ip_field, count, classification, noise, tags, actor, index
+```
+
+## Dashboard guidance
+
+The GreyNoise App ships pre-built dashboards:
+
+- **GreyNoise Intelligence**: top noise sources, classification breakdown, country and tag distribution
+- **GreyNoise Threat Feed**: newly classified malicious IPs with actor and tag context
+
+Custom dashboard base queries:
+- Top noise countries: group `greynoise_full` by `country`, count rows, sort descending
+- Classification trend: join `greynoise_full` to firewall logs, `timechart` by `classification`
+- Emerging actors: filter `first_seen > -24h`, group by `actor`
+
+## Caveats
+
+- GreyNoise covers IPv4 addresses only. IPv6 addresses return no match.
+- RIOT covers major cloud and CDN ranges but not every benign IP. Absence from RIOT does not imply the IP is malicious.
+- `noise=true` means the IP sends unsolicited traffic to the public internet, not necessarily that it targeted your environment.
+- `gnenrich` consumes API quota. Use the scheduled lookup files for high-volume or recurring searches.
+- Lookup file freshness depends on the sync schedule configured in the app. Use `gnenrich` when real-time accuracy matters.

--- a/splunk-enrichment-query-builder/references/multi-index-patterns.md
+++ b/splunk-enrichment-query-builder/references/multi-index-patterns.md
@@ -1,0 +1,136 @@
+# Multi-Index Query Patterns
+
+## Use this file when
+
+- the user provides a list of two or more Splunk indexes
+- a hunt or detection needs to cover multiple data sources in one query
+- you need to enumerate what is inside a set of provided indexes before writing a production query
+- per-index sourcetype schemas differ and need separate filters
+
+## Discovery pass (run first when sourcetypes are unknown)
+
+Enumerate sourcetypes across all provided indexes:
+
+```spl
+| tstats count where index IN (idx1, idx2, idx3) by index, sourcetype
+| sort - count
+```
+
+Scope to one index and add host:
+
+```spl
+| tstats count where index=idx1 by host, sourcetype
+```
+
+Return these queries (and stop) before writing a production query when:
+- the exact sourcetype within a provided index is unknown
+- a CIM-backed detection is requested but data model coverage is unconfirmed
+- the query depends on a field name that may vary by add-on or parser
+
+## Index filter patterns
+
+### Preferred: `index IN (...)` (Splunk 8.2+)
+
+```spl
+index IN (firewall, proxy, dns) sourcetype=pan:traffic earliest=-24h
+| stats count by src, dest, dest_port
+```
+
+`index IN (...)` is evaluated at the Bloom filter layer and scales better than an equivalent `OR` chain.
+
+### `OR` chain (Splunk 7.x and earlier, or when only two indexes)
+
+```spl
+(index=firewall OR index=proxy) sourcetype=pan:traffic earliest=-24h
+```
+
+### Per-index sourcetype filter (when schemas differ across indexes)
+
+When indexes feed different add-ons with different field names, filter per-index and normalize with `coalesce`:
+
+```spl
+((index=firewall sourcetype=cisco:asa) OR (index=proxy sourcetype=bluecoat:proxysg:access:kv) OR (index=dns sourcetype=cisco:umbrella:dns))
+earliest=-24h
+| eval common_src=coalesce(src, src_ip, ClientIP)
+| eval common_dest=coalesce(dest, dest_ip, url)
+| stats count by common_src, common_dest, sourcetype
+```
+
+### CIM-backed multi-index query (preferred when CIM is populated)
+
+One `tstats` call covers all contributing sourcetypes regardless of index. The CIM data model handles the fan-out:
+
+```spl
+| tstats summariesonly=true count from datamodel=Network_Traffic.All_Traffic
+  where index IN (firewall, proxy)
+  by All_Traffic.src, All_Traffic.dest, All_Traffic.dest_port, index, sourcetype
+```
+
+Drop `summariesonly=true` when the model is not accelerated or events are very recent (within the last few minutes).
+
+### Subsearch from a lookup (dynamic index list)
+
+When the index list is stored in a CSV lookup file:
+
+```spl
+[inputlookup index_list.csv | rename index_name as index | return 100 index]
+sourcetype=pan:traffic earliest=-24h
+```
+
+`return` converts each row into an `OR`-ed index filter up to the specified row limit.
+
+### Macro expansion (for recurring multi-index queries)
+
+Define a macro `security_indexes` that expands to the standard index filter:
+
+```spl
+`security_indexes` sourcetype=pan:traffic earliest=-24h
+```
+
+Macro definition in Splunk: `index IN (firewall, proxy, dns, endpoint)`.
+
+## tstats patterns across multiple indexes
+
+Enumerate indexed fields and counts by index:
+
+```spl
+| tstats count where index IN (idx1, idx2, idx3) by index, sourcetype, _time span=1d
+```
+
+Verify that a specific field is indexed before using it as a filter:
+
+```spl
+| tstats values(src) where index IN (firewall, proxy) by index, sourcetype
+```
+
+An empty result for a field means the field is not index-time extracted; a raw-event search with inline extraction is required.
+
+## Per-index summary in one pass
+
+Produce counts broken down by index and sourcetype:
+
+```spl
+index IN (firewall, proxy, endpoint) earliest=-24h
+| stats count by index, sourcetype
+| sort - count
+```
+
+## Iterating over a user-provided index list
+
+When the user provides N index names, build the filter dynamically and validate with a discovery pass first:
+
+```spl
+| tstats count where index IN (user_index_1, user_index_2, user_index_3) by index, sourcetype, _time span=1h
+| sort - count
+```
+
+After sourcetypes are confirmed, replace with the production query using the same `index IN (...)` filter.
+
+## Performance guidance
+
+- Always specify `earliest` and `latest` before other filters; time bounds are the first optimization Splunk applies.
+- Add `sourcetype=` after the index filter when sourcetypes are known. This eliminates unrelated events before any pipeline processing.
+- Use `| tstats` for counting, bucketing, and summary queries. It reads TSIDX metadata and avoids raw event decompression.
+- Avoid `index=*` in production queries. Enumerate known indexes explicitly.
+- When different indexes feed the same CIM data model, one `tstats from datamodel=` query replaces N `OR`-ed sourcetype filters.
+- For high-cardinality fields, use `tstats count` grouped by that field rather than `stats` on raw events.

--- a/splunk-enrichment-query-builder/references/splunk-cloud-index-management.md
+++ b/splunk-enrichment-query-builder/references/splunk-cloud-index-management.md
@@ -1,0 +1,154 @@
+# Splunk Cloud Platform Index Management
+
+## Use this file when
+
+- the environment is Splunk Cloud (not Splunk Enterprise on-prem)
+- you need to enumerate, create, or validate indexes in Splunk Cloud
+- the query involves `_internal`, `_audit`, or other system indexes
+- index retention or sizing constraints affect query design
+- federated search across Splunk Cloud stacks is required
+- the user asks about index limits, naming rules, or data archive options
+
+## Stack types
+
+Splunk Cloud runs on two infrastructure models:
+
+| Feature | Victoria stack | Classic (Federated) stack |
+| --- | --- | --- |
+| Self-service index creation | Yes, via Settings > Indexes in Splunk Web | No; requires a Splunk Support case |
+| REST API index management | Yes, with a management token | Limited; structural changes go through Support |
+| Direct forwarder port (9997) | Yes | Yes |
+| HEC ingestion | Yes | Yes |
+| `_internal` access | Admin role via `splunk_system_user` | Restricted by default |
+| Storage tiers | Hot/Warm/Frozen + Dynamic Data Active Archive | Same |
+| Self-service index count | Up to the subscription tier limit | Same via Support |
+
+Victoria is the default for new Splunk Cloud deployments. Classic stacks remain for legacy customers.
+
+## Index naming constraints
+
+Rules that apply to both stack types:
+
+- Lowercase letters, digits, hyphens (`-`), and underscores (`_`) only.
+- Maximum 80 characters.
+- Cannot start with a hyphen or underscore.
+- Reserved prefixes: `_` (system indexes) and `dm_` (data model summary indexes).
+- Valid examples: `firewall`, `prod-windows-endpoint`, `aws_cloudtrail_2024`.
+
+## Index types
+
+| Type | `datatype` value | Use case |
+| --- | --- | --- |
+| Event | `event` | Timestamped log events (default) |
+| Metric | `metric` | Numeric time-series data for `mstats` queries |
+| Summary | `summary` | Accelerated `sistats`/`sitimechart` output |
+
+`datatype` is set at creation time and cannot be changed afterward.
+
+## Key index properties
+
+| Property | Description | Default on Splunk Cloud |
+| --- | --- | --- |
+| `maxTotalDataSizeMB` | Maximum on-disk size before data is frozen | Subscription-dependent; often 500 GB per index |
+| `frozenTimePeriodInSecs` | Age in seconds after which events freeze (deleted or archived) | 188697600 (approximately 6 years) |
+| `homePath` | Hot/warm bucket path | Platform-managed; do not set manually |
+| `coldPath` | Cold bucket path | Platform-managed |
+| `enableDataIntegrityControl` | SHA-256 hash per bucket for tamper detection | Configurable on request |
+
+On Splunk Cloud, `homePath` and `coldPath` are platform-managed. Setting them manually causes errors.
+
+## Dynamic Data Active Archive (DDAA)
+
+DDAA provides long-term object-storage retention beyond the standard frozen window:
+
+- Archived data is retained in object storage (S3-equivalent) and is searchable on demand.
+- Archived buckets are not immediately queryable; a restore operation warms them to an accessible tier first.
+- Use `frozenTimePeriodInSecs` to control when events transition from cold to the archive tier.
+- DDAA requires a separate subscription entitlement. Contact Splunk to enable it.
+
+When writing queries that may touch archived data, budget additional latency and inform the user that a restore step may be needed.
+
+## Enumerating indexes via REST (management token required)
+
+```spl
+| rest /services/data/indexes splunk_server=local
+| table title, datatype, totalEventCount, frozenTimePeriodInSecs, maxTotalDataSizeMB, disabled
+```
+
+List only enabled event indexes sorted by event volume:
+
+```spl
+| rest /services/data/indexes splunk_server=local
+| where datatype="event" AND disabled=0
+| table title, totalEventCount, frozenTimePeriodInSecs, maxTotalDataSizeMB
+| sort - totalEventCount
+```
+
+On Splunk Cloud, `splunk_server` must be `local` or the search head hostname. Wildcard REST calls to indexers are blocked by default.
+
+## Enumerating indexes via tstats (no admin permissions required)
+
+Any user whose role grants read access to an index can enumerate it:
+
+```spl
+| tstats count where index=* by index
+| sort - count
+```
+
+Scoped to known indexes (faster and safer in production):
+
+```spl
+| tstats count where index IN (firewall, proxy, endpoint, cloud) by index, sourcetype
+```
+
+## System indexes and access restrictions
+
+| Index | Contents | Splunk Cloud access |
+| --- | --- | --- |
+| `_internal` | Platform logs: scheduler, metrics, dispatch | Admin via `splunk_system_user` role only |
+| `_audit` | Search audit and file integrity events | Admin role only |
+| `_introspection` | Splunk performance metrics | Admin role only |
+| `_telemetry` | Anonymous usage telemetry | Not user-accessible |
+| `history` | Search job history | Owner only |
+| `summary` | Output from scheduled summary searches | User-accessible if role grants it |
+
+If a query must target `_internal` (for audit or performance investigation), use the Splunk Monitoring Console or request a platform-managed query through Splunk Support.
+
+## Federated search
+
+Federated search allows a Splunk Cloud deployment to query an external Splunk Enterprise environment or a second Splunk Cloud stack as a remote peer:
+
+```spl
+| federated index=remote_firewall sourcetype=cisco:asa earliest=-24h
+| stats count by src, dest
+```
+
+Prerequisites:
+- A federated provider configured under Settings > Federated Search.
+- Network connectivity and mutual trust between the environments.
+- The `federated` keyword replaces the standard `index=` prefix in the search.
+
+## Creating an index (Victoria, self-service)
+
+**Splunk Web**: Settings > Indexes > New Index > fill in name, type, and retention.
+
+**REST API** (management token required):
+
+```bash
+curl -k -H "Authorization: Bearer YOUR_TOKEN" \
+  https://YOUR-STACK.splunkcloud.com:8089/services/data/indexes \
+  -d name=new_index \
+  -d datatype=event \
+  -d frozenTimePeriodInSecs=7776000
+```
+
+**Classic stack**: open a Splunk Support case with the index name, type, retention period, and maximum size.
+
+## Query design considerations for Splunk Cloud
+
+- Always specify `earliest` and `latest`; Splunk Cloud deployments often hold years of data across many indexes.
+- Use explicit `index IN (...)` filters rather than `index=*`.
+- `_internal` queries require admin access and should go through the Monitoring Console.
+- For high-volume indexes, use `tstats` with a CIM data model to avoid raw event scans.
+- Archived data in DDAA is not immediately searchable; restore latency may be minutes to hours depending on bucket count.
+- REST API calls to `/services/data/indexes` on Classic stacks may be blocked or return partial results without a management token.

--- a/splunk-enrichment-query-builder/references/splunkbase-app-catalog.md
+++ b/splunk-enrichment-query-builder/references/splunkbase-app-catalog.md
@@ -1,0 +1,335 @@
+# Splunkbase App and Add-on Catalog
+
+## Use this file when
+
+- the user names a vendor product or Splunkbase add-on and the query needs to know its sourcetypes, key fields, or CIM data model mappings
+- you need to verify what fields an add-on produces before writing a detection
+- the user provides index names and you need to infer likely sourcetypes from them
+
+## Splunkbase listing metadata
+
+Each Splunkbase listing describes:
+
+| Metadata | Description |
+| --- | --- |
+| App name / slug | Installable package name (e.g., `Splunk_TA_paloalto`) |
+| Type | Add-on (TA) vs. App vs. Premium App |
+| CIM version | Which CIM release the add-on targets |
+| Platform compatibility | Splunk Cloud, Enterprise (on-prem), or both |
+| Inputs | How data is collected: forwarder, modular input, HEC, REST poll |
+| Sourcetypes | The `sourcetype` values the add-on assigns to parsed events |
+| CIM tags | Which CIM data models the add-on populates via `eventtypes.conf` and `tags.conf` |
+| Lookups | Reference tables shipped with the add-on |
+| Custom commands | Any SPL commands the add-on registers |
+
+## Verifying an installed add-on
+
+List installed add-ons:
+
+```spl
+| rest /services/apps/local | search title="Splunk_TA_*" OR title="TA-*" | table title, version, visible
+```
+
+Check CIM tagging for a sourcetype:
+
+```spl
+sourcetype=YOUR_SOURCETYPE | head 5 | table tag, eventtype, sourcetype
+```
+
+Verify CIM coverage:
+
+```spl
+| tstats count from datamodel=Web.Web by sourcetype
+```
+
+## Endpoint security add-ons
+
+### Splunk Add-on for Microsoft Windows (`Splunk_TA_windows`)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `WinEventLog:Security` | Authentication, Endpoint | EventCode, user, src_user, dest, action |
+| `XmlWinEventLog:Security` | Authentication, Endpoint | EventCode, user, src_user, dest, action |
+| `WinEventLog:System` | Change | EventCode, host |
+| `WinEventLog:Application` | Change | EventCode, host |
+| `Perfmon:*` | Performance | object, counter, instance, Value |
+
+Key EventCodes: 4624/4625 (logon/fail), 4648 (explicit logon), 4688 (process create), 4720/4726 (account create/delete), 4776 (NTLM auth), 4768/4769 (Kerberos TGT/TGS), 4663 (object access), 7045 (service install).
+
+### Splunk Add-on for Microsoft Sysmon (`Splunk_TA_microsoft_sysmon`)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `XmlWinEventLog:Microsoft-Windows-Sysmon/Operational` | Endpoint (Processes, Filesystem, Registry, NetworkTraffic) | EventCode, process, process_id, parent_process, dest, user, hash, TargetFilename, TargetObject |
+
+Key EventCodes: 1 (process create), 3 (network connect), 7 (image load), 8 (create remote thread), 10 (process access), 11 (file create), 12/13/14 (registry), 22 (DNS query).
+
+### CrowdStrike Falcon Event Streams
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `crowdstrike:events:sensor` | Endpoint, Malware, Intrusion_Detection | event_type, ComputerName, UserName, ImageFileName, CommandLine, SHA256HashData, Severity |
+| `crowdstrike:fdr:json` | Endpoint | event_simpleName, ContextBaseFileName, CommandLine, SHA256HashData, LocalAddressIP4, RemoteAddressIP4 |
+
+Caveat: FDR field names differ from Event Streams; verify before reusing a query across both feeds.
+
+### Microsoft Defender for Endpoint (`Splunk_TA_microsoft_defender`)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `ms:defender:atp:alerts` | Alerts, Malware, Endpoint | AlertId, Severity, title, machineId, computerDnsName, sha256, fileName, user |
+
+On-host Windows Defender operational log (via `Splunk_TA_windows`):
+
+| Sourcetype | Source | CIM data model | Key fields |
+| --- | --- | --- | --- |
+| `XmlWinEventLog` | `Microsoft-Windows-Windows Defender/Operational` | Malware | EventCode (1116/1117), Severity Name, Path, Threat Name |
+
+### Carbon Black (VMware Carbon Black Cloud)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `carbonblack:events` | Endpoint, Malware | process_name, cmdline, parent_name, sha256, device_name, username |
+
+## Network security add-ons
+
+### Palo Alto Networks Add-on (`Splunk_TA_paloalto`)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `pan:traffic` | Network_Traffic | src, dest, dest_port, app, rule, action, bytes_in, bytes_out, transport |
+| `pan:threat` | Intrusion_Detection, Web (url subtype), Malware (wildfire subtype) | signature, severity, action, category, url, file_hash |
+| `pan:globalprotect` | Authentication, Network_Sessions | user, src, action, machine |
+| `pan:system` | -- | eventid, object, result |
+| `pan:hip-match` | -- | host_id, match_name, user |
+
+### Cisco ASA (`Splunk_TA_cisco_asa`)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `cisco:asa` | Network_Traffic, Authentication, Network_Sessions | src, dest, dest_port, action, transport, user, bytes_in, bytes_out, signature |
+
+Key message IDs: %ASA-6-106015 (deny by ACL), %ASA-5-111008 (user command), %ASA-6-716001 (VPN connect).
+
+### Cisco Firepower / FTD eStreamer
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `cisco:estreamer:data` | Intrusion_Detection, Network_Traffic | ImpactBits, Severity, SignatureId, GeneratorId, src, dest |
+
+### Cisco Umbrella (`TA-cisco-umbrella`)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `cisco:umbrella:dns` | Network_Resolution, Web (proxied traffic) | src, query, action, category, reply_code |
+
+### Cisco ISE
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `cisco:ise:syslog` | Authentication, Network_Sessions | user, src, dest, action, authentication_method, endpoint_id |
+
+### Fortinet FortiGate
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `fgt_traffic` | Network_Traffic | srcip, dstip, dstport, action, app, proto, rcvdbyte, sentbyte |
+| `fgt_log` | Intrusion_Detection, Web | subtype, level, msg, action |
+
+### Check Point
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `cp_log` | Network_Traffic, Intrusion_Detection | orig, src, dst, service, action, rule, proto |
+
+### Juniper Junos
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `juniper:junos` | Network_Traffic | src, dest, dest_port, action, transport |
+
+### F5 BIG-IP
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `f5:bigip:ltm:access:accesspolicyresult` | Authentication | user, src, dest |
+| `f5:bigip:apm:access` | Authentication, Network_Sessions | user, src, session_id |
+| `f5:bigip:asm:syslog` | Web, Intrusion_Detection | attack_type, violations, src_ip, dest_ip, request |
+
+## Web and proxy add-ons
+
+### Zscaler (`Splunk_TA_zscaler` / NSS or Cloud NSS)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `zscalernss-web` | Web | src, dest, url, action, status, user, bytes_in, bytes_out, category |
+| `zscalernss-fw` | Network_Traffic | src, dest, dest_port, action, transport |
+| `zscalernss-dns` | Network_Resolution | src, query, reply_code |
+| `zscalerlss-zpa-app` | Network_Sessions, Web | user, src_ip, dest_ip, app |
+
+### Symantec ProxySG / Blue Coat
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `bluecoat:proxysg:access:kv` | Web | src, dest, url, action, status, http_method, http_user_agent, bytes_in, bytes_out, category |
+
+### Cloudflare (`cloudflare-app-for-splunk`)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `cloudflare:json` | Web, Intrusion_Detection, Network_Resolution | ClientIP, ClientRequestURI, EdgeResponseStatus, WAFAction, WAFRuleID, QueryName |
+
+Field availability depends on Logpush field selection; treat as partial until verified.
+
+### Akamai SIEM Integration
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `akamai:siem` | Web, Intrusion_Detection | attackData.rules, attackData.ruleActions, httpMessage.requestHeaders, geo.country |
+
+### Squid Proxy
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `squid:access` | Web | src, dest, url, action, status, http_method, bytes_out |
+
+### Imperva WAF
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `imperva:waf` | Web, Intrusion_Detection | src, dest, url, action, severity, sig_id, http_method |
+
+## Email security add-ons
+
+### Proofpoint TAP
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `proofpoint:tap:siem` | Email, Malware | sender, recipient, subject, url, hash, action, threatStatus |
+
+### Proofpoint Protection Server (PPS)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `pps_messagelog` | Email | sender, recipients, subject, action, disposition |
+
+## Identity and access add-ons
+
+### Okta Add-on for Splunk (`Splunk_TA_okta`)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `okta:im2` | Authentication | user, src_ip, action, outcome, authenticationContext.authenticationStep, client.userAgent.rawUserAgent |
+
+### Duo Security Add-on
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `duo:authentication` | Authentication | user, result, reason, factor, ip, integration |
+
+### Active Directory (via `Splunk_TA_windows`)
+
+Events from `WinEventLog:Security` cover AD authentication. Additional AD-specific channels:
+
+| Sourcetype | Source | CIM data model | Key fields |
+| --- | --- | --- | --- |
+| `WinEventLog` | `Active Directory Web Services` | Change | EventCode, src_user, dest_user |
+
+## DNS and network resolution add-ons
+
+### Infoblox (`TA-infoblox`)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `infoblox:dns` | Network_Resolution | src, query, record_type, reply_code, answer |
+| `infoblox:dhcp` | Network_Sessions | src_ip, dest, lease_time, mac |
+
+### Windows DNS (via `Splunk_TA_windows`)
+
+| Sourcetype | Source | CIM data model | Key fields |
+| --- | --- | --- | --- |
+| `XmlWinEventLog` | `Microsoft-Windows-DNS-Server/Analytical` | Network_Resolution | EventCode, QNAME, QTYPE, PacketData |
+
+## Cloud platform add-ons
+
+### Splunk Add-on for AWS (`Splunk_TA_aws`)
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `aws:cloudtrail` | Authentication, Change | eventName, userIdentity.arn, sourceIPAddress, errorCode, awsRegion |
+| `aws:s3:accesslogs` | Web | remote_ip, bucket, key, operation, http_status, bytes_sent |
+| `aws:vpc:flow` | Network_Traffic | srcAddr, dstAddr, dstPort, protocol, action, logStatus |
+| `aws:guardduty` | Alerts, Intrusion_Detection | type, severity, description, resource.instanceDetails |
+| `aws:securityhub` | Alerts | Title, Severity.Label, ProductArn, FindingProviderFields |
+| `aws:config` | Change | configurationItem.resourceType, changeType |
+
+### Splunk Add-on for Microsoft Azure
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `mscs:azure:audit` | Change, Authentication | operationName, caller, resultType |
+| `mscs:azure:nsg:flow` | Network_Traffic | src_ip, dest_ip, dest_port, protocol, action |
+| `azure:monitor:aad:signin` | Authentication | userPrincipalName, ipAddress, status.errorCode, clientAppUsed, location |
+| `azure:monitor:aad:audit` | Change | operationType, result, initiatedBy |
+
+### Splunk Add-on for Google Cloud
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `google:gcp:buckets:accesslogs` | Web | remoteIp, resource, status, bytesSent |
+| `google:gcp:cloudaudit:data_access` | Authentication, Change | protoPayload.methodName, protoPayload.authenticationInfo.principalEmail |
+
+## Vulnerability management add-ons
+
+### Tenable Add-on for Splunk
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `tenable:io:vulnerabilities` | Vulnerabilities | severity, plugin_name, cve, dest, port |
+| `tenable:io:assets` | -- | ip, hostname, os, last_seen |
+
+### Qualys Add-on
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `qualys:vuln` | Vulnerabilities | severity, qid, title, ip, port |
+
+## Threat intelligence add-ons (lookups only, no sourcetypes)
+
+These add-ons provide lookup files and custom commands, not sourcetypes.
+
+| Add-on | Lookup / command | Key fields |
+| --- | --- | --- |
+| GreyNoise App for Splunk | `greynoise_full.csv`, `greynoise_riot.csv`, `gnenrich`, `gnlookup` | ip, noise, riot, classification, tags, actor |
+| Recorded Future App | `recordedfuture_threat` lookup | risk_score, evidence_summary, triggered_rules |
+| VirusTotal Add-on | `vt` custom command | positives, permalink, scan_date |
+
+See [greynoise-integration.md](greynoise-integration.md) for GreyNoise field details and SPL patterns.
+
+## NetFlow add-ons
+
+### Splunk Add-on for NetFlow
+
+| Sourcetype | CIM data model | Key fields |
+| --- | --- | --- |
+| `netflow` | Network_Traffic | src_ip, dst_ip, dst_port, protocol, in_bytes, out_bytes, packets |
+
+## Inferring sourcetypes from index name patterns
+
+When the user provides index names but no sourcetypes, apply these heuristics before returning a discovery query:
+
+| Index name pattern | Likely sourcetypes | First step |
+| --- | --- | --- |
+| `*firewall*`, `*paloalto*`, `*pan*` | `pan:traffic`, `cisco:asa`, `fgt_traffic` | `tstats count where index=NAME by sourcetype` |
+| `*network*`, `*netflow*` | `netflow`, `pan:traffic` | same |
+| `*endpoint*`, `*edr*`, `*crowdstrike*` | `crowdstrike:events:sensor`, `WinEventLog:Security` | same |
+| `*proxy*`, `*web*`, `*zscaler*` | `zscalernss-web`, `bluecoat:proxysg:access:kv` | same |
+| `*dns*` | `cisco:umbrella:dns`, `infoblox:dns` | same |
+| `*cloud*`, `*aws*` | `aws:cloudtrail`, `aws:vpc:flow` | same |
+| `*azure*` | `mscs:azure:audit`, `azure:monitor:aad:signin` | same |
+| `*email*`, `*mail*`, `*proofpoint*` | `proofpoint:tap:siem`, `pps_messagelog` | same |
+| `*auth*`, `*iam*`, `*identity*` | `okta:im2`, `duo:authentication` | same |
+| `*vuln*` | `tenable:io:vulnerabilities`, `qualys:vuln` | same |
+| `*windows*`, `*winevent*` | `WinEventLog:Security`, `XmlWinEventLog:Security` | same |
+
+Always confirm with `tstats count where index=NAME by sourcetype` before writing a production query.


### PR DESCRIPTION
## Summary

- Adds a third skill, `splunk-enrichment-query-builder`, covering three scenarios not handled by the existing skills: multi-index queries, Splunkbase add-on catalog lookups, and GreyNoise IP enrichment.
- Extends the validator to cover the new skill's required files, frontmatter, openai.yaml key presence, and claude-opus/codex helper drift detection.
- Updates README and QUERY_SKILL_PLAN with the new skill directory, invocation example, common use cases, and file list.

## What the new skill covers

### Multi-index patterns (`references/multi-index-patterns.md`)
- `index IN (...)` syntax (Splunk 8.2+) vs. `OR` chains
- Per-index sourcetype filters with `coalesce` normalization when schemas differ
- CIM-backed `tstats` across multiple indexes in one call
- Subsearch-from-lookup and macro expansion for dynamic index lists
- Discovery pass (enumerate sourcetypes first) as the required first step when sourcetypes are unknown

### Splunkbase add-on catalog (`references/splunkbase-app-catalog.md`)
30+ major security add-ons documented with canonical sourcetypes, key fields, CIM model mappings, and index-name heuristics. Covers:
- Endpoint: Windows (`Splunk_TA_windows`), Sysmon, CrowdStrike Falcon, Defender for Endpoint, Carbon Black
- Network: PAN-OS, Cisco ASA/FTD/Umbrella/ISE, Fortinet, Check Point, Juniper, F5
- Web/proxy: Zscaler, ProxySG, Cloudflare, Akamai, Squid, Imperva
- Email: Proofpoint TAP and PPS
- Identity: Okta, Duo
- DNS: Infoblox, Windows DNS
- Cloud: AWS, Azure, GCP
- Vulnerability: Tenable, Qualys
- Threat intel lookups: GreyNoise, Recorded Future, VirusTotal

### GreyNoise enrichment (`references/greynoise-integration.md`)
- `gnlookup`, `gnenrich`, `gnmeta` command reference
- `greynoise_full` and `greynoise_riot` lookup join patterns (for when custom commands are unavailable)
- Full field reference (ip, noise, riot, classification, tags, actor, cve, country, asn, etc.)
- Common patterns: noise filter, malicious IP detection, RIOT pre-filter, emerging threat feed, multi-index IP enrichment

### Splunk Cloud index management (`references/splunk-cloud-index-management.md`)
- Victoria vs. Classic stack differences (self-service vs. Support-ticket index creation)
- Index naming constraints, type options, key properties
- Dynamic Data Active Archive (DDAA) for long-term retention
- REST API enumeration (`| rest /services/data/indexes`) and `tstats` enumeration without admin rights
- System index access restrictions (`_internal`, `_audit`, etc.)
- Federated search syntax
- Query design considerations specific to Splunk Cloud

## Test plan

- [ ] Run `scripts/validate-skill-pack.ps1` (or equivalent Python check) — all required files present, frontmatter valid, openai.yaml keys present, helper drift clean, no broken local links, no non-ASCII characters
- [ ] Invoke `$splunk-enrichment-query-builder` with a multi-index prompt and verify discovery mode triggers when sourcetypes are omitted
- [ ] Invoke with known sourcetypes and verify the catalog reference maps them to CIM fields
- [ ] Invoke with GreyNoise enabled and verify `gnenrich` / lookup fallback pattern is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC

---
_Generated by [Claude Code](https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC)_