### PR TITLE
Fix 10 code-review findings across all skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,9 @@ To get the best results with either model:
 - [scripts/validate-skill-pack.ps1](scripts/validate-skill-pack.ps1): local validation for metadata, links, helpers, and encoding
 - [splunk-data-dictionary-builder/SKILL.md](splunk-data-dictionary-builder/SKILL.md): skill for building Splunk data dictionaries, including the JSON output shape
 - [splunk-data-dictionary-builder/references/workflow.md](splunk-data-dictionary-builder/references/workflow.md): discovery strategy, CIM coverage, and query-builder handoff
-- [agents/openai.yaml](splunk-sentinel-query-builder/agents/openai.yaml): UI metadata and default skill prompt
-- [agents/codex-gpt-5.4.yaml](splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml): detailed Codex/OpenAI companion helper
-- [agents/claude-opus.yaml](splunk-sentinel-query-builder/agents/claude-opus.yaml): companion helper for Claude-style prompting
+- [splunk-sentinel-query-builder/agents/openai.yaml](splunk-sentinel-query-builder/agents/openai.yaml): UI metadata and default skill prompt
+- [splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml](splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml): detailed Codex/OpenAI companion helper
+- [splunk-sentinel-query-builder/agents/claude-opus.yaml](splunk-sentinel-query-builder/agents/claude-opus.yaml): companion helper for Claude-style prompting
 - [splunk-sentinel-query-builder/SKILL.md](splunk-sentinel-query-builder/SKILL.md): main skill instructions
 - [references/query-workflow.md](splunk-sentinel-query-builder/references/query-workflow.md): query workflow
 - [references/cim-vendor-alignment.md](splunk-sentinel-query-builder/references/cim-vendor-alignment.md): CIM data models and vendor sourcetype mappings

--- a/scripts/validate-skill-pack.ps1
+++ b/scripts/validate-skill-pack.ps1
@@ -75,6 +75,10 @@ function Assert-ListsEqual {
         [string[]]$Right
     )
 
+    if ($Left.Count -eq 0 -and $Right.Count -eq 0) {
+        Add-Issue "Helper drift: $Name is missing or empty in both files"
+        return
+    }
     $leftText = ($Left -join "`n")
     $rightText = ($Right -join "`n")
     if ($leftText -ne $rightText) {
@@ -143,30 +147,20 @@ foreach ($skill in @("splunk-sentinel-query-builder/SKILL.md", "splunk-data-dict
     Assert-Contains $skill '## Inputs' "Inputs section"
 }
 
-$openai = Read-Text "splunk-sentinel-query-builder/agents/openai.yaml"
-foreach ($key in @("interface:", "display_name:", "short_description:", "default_prompt:", "policy:", "allow_implicit_invocation: false")) {
-    if ($openai -notmatch [regex]::Escape($key)) {
-        Add-Issue "agents/openai.yaml is missing $key"
+$requiredOpenaiKeys = @("interface:", "display_name:", "short_description:", "default_prompt:", "policy:", "allow_implicit_invocation: false")
+foreach ($skill in @("splunk-sentinel-query-builder", "splunk-data-dictionary-builder", "splunk-enrichment-query-builder")) {
+    $skillOpenai = Read-Text "$skill/agents/openai.yaml"
+    foreach ($key in $requiredOpenaiKeys) {
+        if ($skillOpenai -notmatch [regex]::Escape($key)) {
+            Add-Issue "$skill/agents/openai.yaml is missing $key"
+        }
     }
 }
 
-$dictionaryOpenai = Read-Text "splunk-data-dictionary-builder/agents/openai.yaml"
-foreach ($key in @("interface:", "display_name:", "short_description:", "default_prompt:", "policy:", "allow_implicit_invocation: false")) {
-    if ($dictionaryOpenai -notmatch [regex]::Escape($key)) {
-        Add-Issue "splunk-data-dictionary-builder/agents/openai.yaml is missing $key"
-    }
-}
-
-$enrichmentOpenai = Read-Text "splunk-enrichment-query-builder/agents/openai.yaml"
-foreach ($key in @("interface:", "display_name:", "short_description:", "default_prompt:", "policy:", "allow_implicit_invocation: false")) {
-    if ($enrichmentOpenai -notmatch [regex]::Escape($key)) {
-        Add-Issue "splunk-enrichment-query-builder/agents/openai.yaml is missing $key"
-    }
-}
-
+# Query-builder skills (sentinel, enrichment) use a structured response contract;
+# check that both helper files carry the same sections.
 foreach ($helperPair in @(
     @("splunk-sentinel-query-builder/agents/claude-opus.yaml", "splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml"),
-    @("splunk-data-dictionary-builder/agents/claude-opus.yaml", "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml"),
     @("splunk-enrichment-query-builder/agents/claude-opus.yaml", "splunk-enrichment-query-builder/agents/codex-gpt-5.4.yaml")
 )) {
     $claude = Read-Text $helperPair[0]
@@ -174,6 +168,24 @@ foreach ($helperPair in @(
     foreach ($section in @("prompt_shape", "default_sections", "short_sections", "token_rules", "truth_order", "stop_conditions")) {
         $parent = if ($section -in @("prompt_shape")) { "invocation" } elseif ($section -in @("default_sections", "short_sections")) { "response_contract" } else { "behavior" }
         Assert-ListsEqual "$($helperPair[0]) / $section" (Get-YamlList $claude $parent $section) (Get-YamlList $codex $parent $section)
+    }
+    # claude-opus helpers must carry trigger_tuning; codex helpers must carry packaging_rules.
+    if ($claude -notmatch 'trigger_tuning:') {
+        Add-Issue "$($helperPair[0]) is missing trigger_tuning section"
+    }
+    if ($codex -notmatch 'packaging_rules:') {
+        Add-Issue "$($helperPair[1]) is missing packaging_rules section"
+    }
+}
+
+# Data-dictionary builder uses a simpler helper structure; check only the sections it defines.
+foreach ($helperPair in @(
+    @("splunk-data-dictionary-builder/agents/claude-opus.yaml", "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml")
+)) {
+    $claude = Read-Text $helperPair[0]
+    $codex = Read-Text $helperPair[1]
+    foreach ($section in @("token_rules", "stop_conditions")) {
+        Assert-ListsEqual "$($helperPair[0]) / $section" (Get-YamlList $claude "behavior" $section) (Get-YamlList $codex "behavior" $section)
     }
 }
 

--- a/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
+++ b/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
@@ -7,6 +7,7 @@ import argparse
 import base64
 import json
 import os
+import re
 import ssl
 import sys
 import time
@@ -15,6 +16,8 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
+
+_SAFE_IDENT_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
 
 def env_bool(name: str, default: bool) -> bool:
@@ -98,6 +101,28 @@ def spl_quote(value: str) -> str:
     return f'"{escaped}"'
 
 
+def _safe_spl_ident(value: str, context: str, warnings: list[str]) -> str | None:
+    """Return value if it is safe as an unquoted SPL data-model identifier, else warn and return None."""
+    if _SAFE_IDENT_RE.match(value):
+        return value
+    warnings.append(f"Skipping unsafe SPL identifier for {context}: {value!r}")
+    return None
+
+
+def _redact_url_credentials(url: str) -> str:
+    """Strip userinfo from a URL so credentials are never written to the output file."""
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.username or parsed.password:
+            netloc = parsed.hostname or ""
+            if parsed.port:
+                netloc = f"{netloc}:{parsed.port}"
+            return urllib.parse.urlunparse(parsed._replace(netloc=netloc))
+    except Exception:
+        pass
+    return url
+
+
 # Sourcetype prefixes produced by common Splunkbase add-ons, mapped to the CIM
 # data models they are tagged for. These are offline fallback hints only;
 # cim_coverage (queried from the live instance) is the ground truth and also
@@ -113,6 +138,7 @@ CIM_SOURCETYPE_HINTS: dict[str, list[str]] = {
     "akamai:siem": ["Web", "Intrusion_Detection"],
     "ms:defender:atp:alerts": ["Alerts", "Malware", "Endpoint"],
     "crowdstrike:events:sensor": ["Endpoint", "Malware", "Intrusion_Detection"],
+    "crowdstrike:fdr:json": ["Endpoint"],
     "cloudflare:json": ["Web", "Intrusion_Detection", "Network_Resolution"],
     "proofpoint:tap:siem": ["Email", "Malware"],
     "pps_messagelog": ["Email"],
@@ -143,14 +169,18 @@ def cim_hints_for_sourcetype(sourcetype: str) -> list[str]:
 BASE_DATASET_PARENTS = {"BaseEvent", "BaseTransaction", "BaseSearch"}
 
 
-def parse_json_attribute(value: Any) -> dict[str, Any]:
+def parse_json_attribute(value: Any, warnings: list[str] | None = None, context: str = "") -> dict[str, Any]:
     """Normalize a Splunk REST content attribute that may be a JSON string or a dict."""
     if isinstance(value, str):
         try:
             value = json.loads(value)
         except ValueError:
             return {}
-    return value if isinstance(value, dict) else {}
+    if isinstance(value, dict):
+        return value
+    if value is not None and warnings is not None:
+        warnings.append(f"Expected a JSON object for {context!r}, got {type(value).__name__!r}; skipping")
+    return {}
 
 
 def discover_datamodels(client: SplunkClient, warnings: list[str]) -> list[dict[str, Any]]:
@@ -165,10 +195,10 @@ def discover_datamodels(client: SplunkClient, warnings: list[str]) -> list[dict[
         if not name:
             continue
         content = entry.get("content", {})
-        acceleration = parse_json_attribute(content.get("acceleration"))
+        acceleration = parse_json_attribute(content.get("acceleration"), warnings=warnings, context="acceleration")
         # The model definition (objects, fields) is carried in the
         # "description" content attribute as a JSON document.
-        definition = parse_json_attribute(content.get("description"))
+        definition = parse_json_attribute(content.get("description"), warnings=warnings, context="description")
         root_datasets = [
             obj["objectName"]
             for obj in definition.get("objects", [])
@@ -192,7 +222,11 @@ def discover_cim_coverage(client: SplunkClient, datamodels: list[dict[str, Any]]
     for model in datamodels:
         summaries = "summariesonly=true " if model["accelerated"] else ""
         for root in model["root_datasets"]:
-            search = f"| tstats {summaries}count from datamodel={model['name']}.{root} by sourcetype"
+            model_name = _safe_spl_ident(model["name"], "data model name", warnings)
+            root_name = _safe_spl_ident(root, "root dataset", warnings)
+            if model_name is None or root_name is None:
+                continue
+            search = f"| tstats {summaries}count from datamodel={model_name}.{root_name} by sourcetype"
             try:
                 payload = client.search_oneshot(search, earliest)
             except RuntimeError as error:
@@ -303,7 +337,7 @@ def main() -> int:
 
     output = {
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "splunk_base_url": args.base_url,
+        "splunk_base_url": _redact_url_credentials(args.base_url),
         "indexes": indexes,
         "sourcetypes": sourcetypes,
         "cim_datamodels": datamodels,

--- a/splunk-enrichment-query-builder/SKILL.md
+++ b/splunk-enrichment-query-builder/SKILL.md
@@ -35,7 +35,9 @@ Optional but recommended:
 ### 1. Classify each index
 
 For each provided index name:
-1. If sourcetypes are unknown, return the enumeration query from [multi-index-patterns.md](references/multi-index-patterns.md) and stop before writing a production query.
+1. If sourcetypes are unknown, return the enumeration query from [multi-index-patterns.md](references/multi-index-patterns.md) and stop before writing a production query. Discovery mode output:
+   - **Discovery query**: `| tstats count where index IN (<indexes>) by index, sourcetype | sort - count`
+   - **Next step**: one sentence instructing the user to run the query and re-invoke the skill with the confirmed sourcetypes
 2. If sourcetypes are known or can be inferred from the index name, look them up in [splunkbase-app-catalog.md](references/splunkbase-app-catalog.md) to identify CIM model mappings and key fields.
 3. When the environment is Splunk Cloud, check index naming and REST constraints in [splunk-cloud-index-management.md](references/splunk-cloud-index-management.md).
 

--- a/splunk-enrichment-query-builder/references/greynoise-integration.md
+++ b/splunk-enrichment-query-builder/references/greynoise-integration.md
@@ -110,6 +110,7 @@ index=proxy sourcetype=bluecoat:proxysg:access:kv earliest=-24h
 
 ```spl
 index=firewall sourcetype=cisco:asa action=blocked earliest=-24h
+| where isnotnull(src) AND match(src, "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 | stats count by src
 | lookup greynoise_full ip AS src OUTPUT noise, classification, tags
 | where noise=false AND classification!="benign"
@@ -122,6 +123,7 @@ index=firewall sourcetype=cisco:asa action=blocked earliest=-24h
 ```spl
 index IN (firewall, proxy) earliest=-24h
 | eval ip_field=coalesce(src, src_ip, ClientIP)
+| where isnotnull(ip_field) AND match(ip_field, "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 | stats count by ip_field, index, sourcetype
 | lookup greynoise_full ip AS ip_field OUTPUT classification, actor, tags, last_seen
 | where classification="malicious"
@@ -130,8 +132,11 @@ index IN (firewall, proxy) earliest=-24h
 
 ### RIOT enrichment: identify traffic to major CDNs and SaaS platforms
 
+RIOT covers IPv4 addresses; filter to direct-IP destinations before the lookup join.
+
 ```spl
 index=proxy sourcetype=bluecoat:proxysg:access:kv earliest=-24h
+| where isnotnull(dest) AND match(dest, "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 | stats count by dest
 | lookup greynoise_riot ip AS dest OUTPUT riot, name AS riot_service
 | where riot=true
@@ -152,6 +157,7 @@ index=proxy sourcetype=bluecoat:proxysg:access:kv earliest=-24h
 
 ```spl
 index=firewall sourcetype=cisco:asa action=permitted earliest=-24h
+| where isnotnull(src) AND match(src, "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 | stats count by src
 | lookup greynoise_full ip AS src OUTPUT classification, noise, riot, tags, actor, last_seen
 | where classification="malicious" OR (noise=true AND riot=false)

--- a/splunk-sentinel-query-builder/references/cim-vendor-alignment.md
+++ b/splunk-sentinel-query-builder/references/cim-vendor-alignment.md
@@ -104,7 +104,7 @@ Sourcetypes below are the typical names produced by the standard Splunkbase add-
 ### CrowdStrike Falcon
 
 - Add-on: CrowdStrike Falcon Event Streams: `crowdstrike:events:sensor` -> Endpoint, Malware, Intrusion_Detection: process, parent_process_name, file_hash, dest, user, action, severity, signature.
-- Falcon Data Replicator (FDR) feeds Endpoint at higher volume; field names differ from Event Streams, so verify before reusing a query across both.
+- Falcon Data Replicator (FDR): `crowdstrike:fdr:json` -> Endpoint: event_simpleName, ContextBaseFileName, CommandLine, SHA256HashData, LocalAddressIP4, RemoteAddressIP4. Field names differ from Event Streams; verify before reusing a query across both feeds.
 
 ### Cloudflare
 


### PR DESCRIPTION
## Summary

- **SPL injection** (`build_splunk_dictionary.py`): validate data model name and root dataset identifiers against a safe-character regex (`^[A-Za-z0-9_]+$`) before interpolating into `tstats` SPL; names that fail get a warning and are skipped
- **Credential leakage** (`build_splunk_dictionary.py`): strip userinfo from `base_url` via `_redact_url_credentials()` before writing to the output JSON; prevents passwords embedded in the URL from appearing in the dictionary file
- **`parse_json_attribute` silent false negative** (`build_splunk_dictionary.py`): add optional `warnings`/`context` parameters so callers receive an explicit warning when a JSON array is returned instead of a dict; update `discover_datamodels` call sites
- **CrowdStrike FDR consistency** (`cim-vendor-alignment.md`, `build_splunk_dictionary.py`): promote `crowdstrike:fdr:json` from a caveat note to a named sourcetype entry with key fields; add it to `CIM_SOURCETYPE_HINTS`
- **Validator vacuous parity** (`validate-skill-pack.ps1`): `Assert-ListsEqual` now fails when both files return an empty section list rather than passing vacuously; separate the data-dictionary builder (simpler helper structure) from the query-builder parity loop
- **`trigger_tuning`/`packaging_rules` asymmetry** (`validate-skill-pack.ps1`): add explicit checks that claude-opus helpers carry `trigger_tuning:` and codex helpers carry `packaging_rules:`
- **GreyNoise IPv4 pre-filter** (`greynoise-integration.md`): add `isnotnull` + IPv4 regex guard to the 4 enrichment patterns that lacked it; the multi-index pattern already had this guard
- **README misleading link text** (`README.md`): fix sentinel agent file entries that showed bare filenames (`agents/openai.yaml`) instead of repo-relative paths
- **Discovery mode output contract** (`splunk-enrichment-query-builder/SKILL.md`): define what discovery mode returns (the `tstats` enumeration query + one-sentence next-step instruction) so there is no ambiguity about what to emit when sourcetypes are unknown
- **Validator copy-paste** (`validate-skill-pack.ps1`): collapse three identical `openai.yaml` key-check loops into a single loop over the three skill directories

## Test plan

- [ ] Run `python3 -m py_compile splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py` — should exit 0
- [ ] Verify `_safe_spl_ident` rejects names with spaces or special characters (e.g. `"Network Traffic"` → warning + skip)
- [ ] Verify `_redact_url_credentials("https://user:pass@host:8089")` → `"https://host:8089"`
- [ ] Confirm `crowdstrike:fdr:json` appears in `CIM_SOURCETYPE_HINTS`, `cim-vendor-alignment.md`, and `splunkbase-app-catalog.md`
- [ ] Run `validate-skill-pack.ps1` on the repo root — should exit 0 with no issues
- [ ] Manually remove a section from one helper YAML and confirm the validator now catches it (empty-empty case)
- [ ] Review greynoise-integration.md patterns to confirm IPv4 guards are present on patterns 1, 2, 3, 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC

---
_Generated by [Claude Code](https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC)_