### PR TITLE
Fix validator parser bugs, SPL where-clause booleans, and full-repo review findings

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,10 +18,12 @@ jobs:
         run: ./scripts/validate-skill-pack.ps1
 
       - name: Set up Python
+        if: ${{ !cancelled() }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Compile Python helpers
+        if: ${{ !cancelled() }}
         shell: pwsh
         run: python -m py_compile .\splunk-data-dictionary-builder\scripts\build_splunk_dictionary.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,7 @@ name: Validate skill pack
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/QUERY_SKILL_PLAN.md
+++ b/QUERY_SKILL_PLAN.md
@@ -139,13 +139,14 @@ Each final query should be checked for:
 ## Recommended file layout
 
 ```text
-prompts/siem_fun/
+siem_fun/
 |-- .claude/
 |   `-- settings.json
 |-- .env.example
 |-- .github/
 |   `-- workflows/
 |       `-- validate.yml
+|-- .gitignore
 |-- examples/
 |   `-- golden-prompts.md
 |-- QUERY_SKILL_PLAN.md
@@ -154,7 +155,11 @@ prompts/siem_fun/
 |   `-- validate-skill-pack.ps1
 |-- splunk-data-dictionary-builder/
 |   |-- agents/
+|   |   |-- claude-opus.yaml
+|   |   |-- codex-gpt-5.4.yaml
+|   |   `-- openai.yaml
 |   |-- references/
+|   |   `-- workflow.md
 |   |-- scripts/
 |   |   `-- build_splunk_dictionary.py
 |   `-- SKILL.md

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ siem_fun/
 |-- .claude/
 |   `-- settings.json
 |-- .env.example
+|-- .gitignore
 |-- examples/
 |   `-- golden-prompts.md
 |-- README.md

--- a/examples/golden-prompts.md
+++ b/examples/golden-prompts.md
@@ -172,3 +172,63 @@ Expected output:
 - Does not invent a Splunk index
 - Provides a `tstats` discovery query to identify endpoint process indexes and sourcetypes
 - States that `DeviceName`, `FileName`, and `InitiatingProcessFileName` need local field mappings
+
+## 8. Multi-index enrichment hunt with GreyNoise
+
+Prompt:
+
+```text
+Use $splunk-enrichment-query-builder to hunt for connections to known-malicious IPs.
+Platform: Splunk
+Task: hunt
+Time range: last 24h
+Indexes: firewall, proxy
+Sourcetypes: cisco:asa, bluecoat:proxysg:access:kv
+GreyNoise: yes
+Output style: short
+```
+
+Expected output:
+
+- `Objective`
+- `Query`
+- `Assumptions`
+- Uses `index IN (firewall, proxy)` rather than an `OR` chain
+- Pre-filters to IPv4 values before the `greynoise_full` lookup join
+- Quotes boolean lookup values in `where` clauses (`noise="true"`, not `noise=true`)
+- Does not invent sourcetypes beyond the two provided
+
+## 9. Enrichment discovery mode with unknown sourcetypes
+
+Prompt:
+
+```text
+Use $splunk-enrichment-query-builder to build a detection across index=net_dmz and index=net_core.
+Platform: Splunk
+Task: detection
+Time range: last 7d
+Indexes: net_dmz, net_core
+Output style: full
+```
+
+Expected output:
+
+- Returns discovery mode, not a production detection
+- Provides `| tstats count where index IN (net_dmz, net_core) by index, sourcetype | sort - count`
+- Instructs the user to run the query and re-invoke the skill with confirmed sourcetypes
+- Does not guess sourcetypes for the unfamiliar index names
+
+## 10. Data dictionary build without pasted credentials
+
+Prompt:
+
+```text
+Use $splunk-data-dictionary-builder to discover accessible Splunk indexes, sourcetypes, fields, sample values, and CIM data model coverage, then output a structured data dictionary. Use local credentials from environment variables or CLI arguments, and never ask me to paste secrets into chat.
+```
+
+Expected output:
+
+- Runs `build_splunk_dictionary.py` with credentials from environment variables or CLI arguments
+- Never asks the user to paste a token or password into chat
+- Reports permission gaps explicitly instead of treating missing data as absent
+- Output JSON includes `indexes`, `sourcetypes`, `cim_datamodels`, `cim_coverage`, `field_samples`, and `warnings`

--- a/scripts/validate-skill-pack.ps1
+++ b/scripts/validate-skill-pack.ps1
@@ -179,14 +179,10 @@ foreach ($helperPair in @(
 }
 
 # Data-dictionary builder uses a simpler helper structure; check only the sections it defines.
-foreach ($helperPair in @(
-    @("splunk-data-dictionary-builder/agents/claude-opus.yaml", "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml")
-)) {
-    $claude = Read-Text $helperPair[0]
-    $codex = Read-Text $helperPair[1]
-    foreach ($section in @("token_rules", "stop_conditions")) {
-        Assert-ListsEqual "$($helperPair[0]) / $section" (Get-YamlList $claude "behavior" $section) (Get-YamlList $codex "behavior" $section)
-    }
+$claude = Read-Text "splunk-data-dictionary-builder/agents/claude-opus.yaml"
+$codex = Read-Text "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml"
+foreach ($section in @("token_rules", "stop_conditions")) {
+    Assert-ListsEqual "splunk-data-dictionary-builder helpers / $section" (Get-YamlList $claude "behavior" $section) (Get-YamlList $codex "behavior" $section)
 }
 
 $dictionaryScript = Read-Text "splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py"

--- a/scripts/validate-skill-pack.ps1
+++ b/scripts/validate-skill-pack.ps1
@@ -17,7 +17,17 @@ function Get-RepoFile {
 
 function Read-Text {
     param([string]$RelativePath)
-    return Get-Content -Raw -Path (Get-RepoFile $RelativePath)
+    $path = Get-RepoFile $RelativePath
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        # Assert-Exists reports missing required files; returning empty text
+        # lets the run finish and print every collected issue.
+        return ""
+    }
+    $text = Get-Content -Raw -Path $path
+    if ($null -eq $text) {
+        return ""
+    }
+    return $text
 }
 
 function Assert-Exists {
@@ -34,7 +44,7 @@ function Assert-Contains {
         [string]$Description
     )
     $text = Read-Text $RelativePath
-    if ($text -notmatch $Pattern) {
+    if ($text -cnotmatch $Pattern) {
         Add-Issue "$RelativePath is missing $Description"
     }
 }
@@ -46,14 +56,17 @@ function Get-YamlList {
         [string]$Key
     )
 
-    $sectionPattern = "(?ms)^$([regex]::Escape($Section)):\s*(.*?)(?=^\S|\z)"
+    # ':[ \t]*\r?\n' (not ':\s*') so the match stops at the line break and the
+    # child lines keep their indentation; '\s*' would swallow the first child's
+    # indent and the '^\s{2}' / '^\s{4}' anchors below would never match it.
+    $sectionPattern = "(?ms)^$([regex]::Escape($Section)):[ \t]*\r?\n(.*?)(?=^\S|\z)"
     $sectionMatch = [regex]::Match($Text, $sectionPattern)
     if (-not $sectionMatch.Success) {
         return @()
     }
 
     $sectionBody = $sectionMatch.Groups[1].Value
-    $keyPattern = "(?ms)^\s{2}$([regex]::Escape($Key)):\s*(.*?)(?=^\s{2}\S|\z)"
+    $keyPattern = "(?ms)^\s{2}$([regex]::Escape($Key)):[ \t]*\r?\n(.*?)(?=^\s{2}\S|\z)"
     $keyMatch = [regex]::Match($sectionBody, $keyPattern)
     if (-not $keyMatch.Success) {
         return @()
@@ -81,7 +94,7 @@ function Assert-ListsEqual {
     }
     $leftText = ($Left -join "`n")
     $rightText = ($Right -join "`n")
-    if ($leftText -ne $rightText) {
+    if ($leftText -cne $rightText) {
         Add-Issue "Helper drift detected in $Name"
     }
 }
@@ -128,6 +141,9 @@ foreach ($file in $trackedFiles) {
         continue
     }
     $text = Get-Content -Raw -Path $path
+    if ($null -eq $text) {
+        continue
+    }
     if ($text -match '(?m)^(<<<<<<<|=======|>>>>>>>)') {
         Add-Issue "$file contains a conflict marker"
     }
@@ -151,7 +167,7 @@ $requiredOpenaiKeys = @("interface:", "display_name:", "short_description:", "de
 foreach ($skill in @("splunk-sentinel-query-builder", "splunk-data-dictionary-builder", "splunk-enrichment-query-builder")) {
     $skillOpenai = Read-Text "$skill/agents/openai.yaml"
     foreach ($key in $requiredOpenaiKeys) {
-        if ($skillOpenai -notmatch [regex]::Escape($key)) {
+        if ($skillOpenai -cnotmatch [regex]::Escape($key)) {
             Add-Issue "$skill/agents/openai.yaml is missing $key"
         }
     }
@@ -170,10 +186,10 @@ foreach ($helperPair in @(
         Assert-ListsEqual "$($helperPair[0]) / $section" (Get-YamlList $claude $parent $section) (Get-YamlList $codex $parent $section)
     }
     # claude-opus helpers must carry trigger_tuning; codex helpers must carry packaging_rules.
-    if ($claude -notmatch 'trigger_tuning:') {
+    if ($claude -cnotmatch 'trigger_tuning:') {
         Add-Issue "$($helperPair[0]) is missing trigger_tuning section"
     }
-    if ($codex -notmatch 'packaging_rules:') {
+    if ($codex -cnotmatch 'packaging_rules:') {
         Add-Issue "$($helperPair[1]) is missing packaging_rules section"
     }
 }
@@ -193,7 +209,7 @@ if (-not $hintsBlock.Success) {
 } else {
     foreach ($match in [regex]::Matches($hintsBlock.Groups[1].Value, '(?m)^\s+"([^"]+)":')) {
         $sourcetype = $match.Groups[1].Value
-        if ($cimReference -notmatch [regex]::Escape($sourcetype)) {
+        if ($cimReference -cnotmatch [regex]::Escape($sourcetype)) {
             Add-Issue "CIM hint sourcetype '$sourcetype' is not documented in cim-vendor-alignment.md"
         }
     }

--- a/splunk-data-dictionary-builder/agents/claude-opus.yaml
+++ b/splunk-data-dictionary-builder/agents/claude-opus.yaml
@@ -4,7 +4,7 @@ helper:
   purpose: "Companion helper for building Splunk data dictionaries with Claude-style prompting."
 
 invocation:
-  preferred_prompt: "Use $splunk-data-dictionary-builder to discover accessible Splunk indexes, sourcetypes, fields, and sample values. Use local credentials from environment variables or CLI arguments, and never ask me to paste secrets into chat."
+  preferred_prompt: "Use $splunk-data-dictionary-builder to discover accessible Splunk indexes, sourcetypes, fields, sample values, and CIM data model coverage, then output a structured data dictionary. Use local credentials from environment variables or CLI arguments, and never ask me to paste secrets into chat."
 
 behavior:
   token_rules:

--- a/splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml
+++ b/splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml
@@ -4,7 +4,7 @@ helper:
   purpose: "Companion helper for building Splunk data dictionaries with Codex and OpenAI-style prompting."
 
 invocation:
-  preferred_prompt: "Use $splunk-data-dictionary-builder to discover accessible Splunk indexes, sourcetypes, fields, and sample values. Use local credentials from environment variables or CLI arguments, and never ask me to paste secrets into chat."
+  preferred_prompt: "Use $splunk-data-dictionary-builder to discover accessible Splunk indexes, sourcetypes, fields, sample values, and CIM data model coverage, then output a structured data dictionary. Use local credentials from environment variables or CLI arguments, and never ask me to paste secrets into chat."
 
 behavior:
   token_rules:

--- a/splunk-data-dictionary-builder/agents/openai.yaml
+++ b/splunk-data-dictionary-builder/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Splunk Data Dictionary Builder"
   short_description: "Discover Splunk schema for query-building context"
-  default_prompt: "Use $splunk-data-dictionary-builder to discover accessible Splunk indexes, sourcetypes, fields, and sample values, then output a structured data dictionary without exposing credentials."
+  default_prompt: "Use $splunk-data-dictionary-builder to discover accessible Splunk indexes, sourcetypes, fields, sample values, and CIM data model coverage, then output a structured data dictionary. Use local credentials from environment variables or CLI arguments, and never ask me to paste secrets into chat."
 
 policy:
   allow_implicit_invocation: false

--- a/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
+++ b/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
@@ -17,7 +17,8 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-_SAFE_IDENT_RE = re.compile(r"^[A-Za-z0-9_]+$")
+# fullmatch with no anchors: '$' would also match before a trailing newline.
+_SAFE_IDENT_RE = re.compile(r"[A-Za-z0-9_]+")
 
 
 def env_bool(name: str, default: bool) -> bool:
@@ -67,7 +68,13 @@ class SplunkClient:
             raise ValueError("Provide SPLUNK_TOKEN or SPLUNK_USERNAME/SPLUNK_PASSWORD.")
         try:
             with urllib.request.urlopen(request, context=self.context, timeout=30) as response:
-                return json.loads(response.read().decode("utf-8"))
+                body = response.read().decode("utf-8")
+            try:
+                return json.loads(body)
+            except ValueError as error:
+                raise RuntimeError(
+                    f"Splunk returned non-JSON for {path} (is this the management port, usually 8089?): {body[:200]}"
+                ) from error
         except urllib.error.HTTPError as error:
             body = error.read().decode("utf-8", errors="replace")
             raise RuntimeError(f"Splunk API error {error.code} for {path}: {body}") from error
@@ -87,6 +94,9 @@ class SplunkClient:
                 "output_mode": "json",
                 "search": search,
                 "earliest_time": earliest,
+                # Without count=0 the oneshot endpoint caps output at 100 rows
+                # and silently truncates larger result sets.
+                "count": "0",
             },
         )
 
@@ -103,7 +113,7 @@ def spl_quote(value: str) -> str:
 
 def _safe_spl_ident(value: str, context: str, warnings: list[str]) -> str | None:
     """Return value if it is safe as an unquoted SPL data-model identifier, else warn and return None."""
-    if _SAFE_IDENT_RE.match(value):
+    if _SAFE_IDENT_RE.fullmatch(value):
         return value
     warnings.append(f"Skipping unsafe SPL identifier for {context}: {value!r}")
     return None
@@ -113,14 +123,30 @@ def _redact_url_credentials(url: str) -> str:
     """Strip userinfo from a URL so credentials are never written to the output file."""
     try:
         parsed = urllib.parse.urlparse(url)
-        if parsed.username or parsed.password:
-            netloc = parsed.hostname or ""
-            if parsed.port:
-                netloc = f"{netloc}:{parsed.port}"
-            return urllib.parse.urlunparse(parsed._replace(netloc=netloc))
+        if not (parsed.username or parsed.password):
+            return url
+        netloc = parsed.hostname or ""
+        if parsed.port:
+            netloc = f"{netloc}:{parsed.port}"
+        return urllib.parse.urlunparse(parsed._replace(netloc=netloc))
     except Exception:
-        pass
-    return url
+        # Redaction must fail closed: an unparseable URL may still carry
+        # credentials, so never fall back to the original string.
+        return "<redacted-unparseable-url>"
+
+
+def _content_flag(value: Any) -> bool:
+    """Normalize a REST content boolean that may arrive as bool, int, or the strings '0'/'1'/'true'/'false'."""
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return bool(value)
+
+
+def _collect_search_messages(payload: dict[str, Any], context: str, warnings: list[str]) -> None:
+    """Surface ERROR/FATAL messages that Splunk returns inside an HTTP 200 search response."""
+    for message in payload.get("messages", []):
+        if isinstance(message, dict) and message.get("type") in {"ERROR", "FATAL"}:
+            warnings.append(f"Splunk search message for {context}: {message.get('text', 'unknown error')}")
 
 
 # Sourcetype prefixes produced by common Splunkbase add-ons, mapped to the CIM
@@ -209,7 +235,7 @@ def discover_datamodels(client: SplunkClient, warnings: list[str]) -> list[dict[
         models.append(
             {
                 "name": name,
-                "accelerated": bool(acceleration.get("enabled", False)),
+                "accelerated": _content_flag(acceleration.get("enabled", False)),
                 "root_datasets": root_datasets,
             }
         )
@@ -232,6 +258,7 @@ def discover_cim_coverage(client: SplunkClient, datamodels: list[dict[str, Any]]
             except RuntimeError as error:
                 warnings.append(str(error))
                 continue
+            _collect_search_messages(payload, f"cim_coverage {model_name}.{root_name}", warnings)
             sourcetypes: dict[str, int] = {}
             for row in payload.get("results", []):
                 name = row.get("sourcetype")
@@ -263,7 +290,7 @@ def discover_indexes(client: SplunkClient, requested: list[str] | None, warnings
     for entry in entries(payload):
         name = entry.get("name")
         content = entry.get("content", {})
-        if name and not content.get("disabled", False):
+        if name and not _content_flag(content.get("disabled", False)):
             names.append(name)
     return sorted(set(names))
 
@@ -278,6 +305,7 @@ def discover_sourcetypes(client: SplunkClient, indexes: list[str], earliest: str
     except RuntimeError as error:
         warnings.append(str(error))
         return []
+    _collect_search_messages(payload, "sourcetype discovery", warnings)
     return payload.get("results", [])
 
 
@@ -289,6 +317,7 @@ def sample_fields(client: SplunkClient, index: str, sourcetype: str, earliest: s
         warnings.append(str(error))
         return {"index": index, "sourcetype": sourcetype, "fields": {}, "sample_count": 0}
 
+    _collect_search_messages(payload, f"field sampling {index}/{sourcetype}", warnings)
     fields: dict[str, dict[str, Any]] = {}
     results = payload.get("results", [])
     for event in results:
@@ -313,6 +342,15 @@ def main() -> int:
     args = parse_args()
     if not args.base_url:
         print("Missing --base-url or SPLUNK_BASE_URL.", file=sys.stderr)
+        return 2
+    if not args.token and not (args.username and args.password):
+        print("Missing credentials: provide SPLUNK_TOKEN or SPLUNK_USERNAME/SPLUNK_PASSWORD.", file=sys.stderr)
+        return 2
+    if args.sample_size < 1:
+        print("--sample-size must be at least 1.", file=sys.stderr)
+        return 2
+    if args.max_sourcetypes < 0:
+        print("--max-sourcetypes must not be negative.", file=sys.stderr)
         return 2
 
     warnings: list[str] = []

--- a/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
+++ b/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
@@ -18,7 +18,9 @@ from pathlib import Path
 from typing import Any
 
 # fullmatch with no anchors: '$' would also match before a trailing newline.
-_SAFE_IDENT_RE = re.compile(r"[A-Za-z0-9_]+")
+# Hyphens are permitted in Splunk dataset IDs and cannot break out of an
+# unquoted SPL token, so they are safe to allow.
+_SAFE_IDENT_RE = re.compile(r"[A-Za-z0-9_-]+")
 
 
 def env_bool(name: str, default: bool) -> bool:

--- a/splunk-enrichment-query-builder/agents/claude-opus.yaml
+++ b/splunk-enrichment-query-builder/agents/claude-opus.yaml
@@ -25,6 +25,8 @@ invocation:
     - "Indexes: list of index names"
     - "Sourcetypes: known sourcetypes within those indexes (optional)"
     - "GreyNoise: yes | no"
+    - "Environment: splunk-cloud | self-managed (optional)"
+    - "Data dictionary: URL or pasted excerpt (optional)"
     - "Output style: short | full"
 
 response_contract:

--- a/splunk-enrichment-query-builder/agents/codex-gpt-5.4.yaml
+++ b/splunk-enrichment-query-builder/agents/codex-gpt-5.4.yaml
@@ -25,6 +25,8 @@ invocation:
     - "Indexes: list of index names"
     - "Sourcetypes: known sourcetypes within those indexes (optional)"
     - "GreyNoise: yes | no"
+    - "Environment: splunk-cloud | self-managed (optional)"
+    - "Data dictionary: URL or pasted excerpt (optional)"
     - "Output style: short | full"
 
 response_contract:

--- a/splunk-enrichment-query-builder/references/greynoise-integration.md
+++ b/splunk-enrichment-query-builder/references/greynoise-integration.md
@@ -20,7 +20,7 @@
 
 Install the **GreyNoise App and Add-On for Splunk** from Splunkbase. The app:
 - Registers custom SPL commands (`gnlookup`, `gnenrich`, `gnmeta`)
-- Ships two synced CSV lookup files (`greynoise_full.csv`, `greynoise_riot.csv`)
+- Ships two synced CSV lookup files with matching lookup definitions (`greynoise_full`, `greynoise_riot`); the queries below reference the definition names. If only the raw CSV files exist, use `greynoise_full.csv` / `greynoise_riot.csv` instead.
 - Includes pre-built intelligence dashboards
 - Requires a valid GreyNoise API key configured under the app setup page
 
@@ -44,7 +44,7 @@ Enrich a field containing IP addresses across all rows of the current pipeline. 
 index=firewall sourcetype=cisco:asa earliest=-24h
 | stats count by src
 | gnenrich field=src
-| where noise=true OR classification="malicious"
+| where noise="true" OR classification="malicious"
 | sort - count
 ```
 
@@ -68,7 +68,7 @@ Use the scheduled lookup files when the GreyNoise App is installed but the custo
 index=firewall sourcetype=cisco:asa earliest=-24h
 | stats count by src
 | lookup greynoise_full ip AS src OUTPUT classification, noise, riot, tags, name, last_seen
-| where noise=true OR classification="malicious"
+| where noise="true" OR classification="malicious"
 | sort - count
 ```
 
@@ -80,7 +80,7 @@ Use RIOT as a pre-filter to remove large-platform traffic before investigating:
 index=proxy sourcetype=bluecoat:proxysg:access:kv earliest=-24h
 | stats count by dest
 | lookup greynoise_riot ip AS dest OUTPUT riot, name AS riot_service
-| where isnull(riot) OR riot=false
+| where isnull(riot) OR riot="false"
 | sort - count
 ```
 
@@ -104,6 +104,8 @@ index=proxy sourcetype=bluecoat:proxysg:access:kv earliest=-24h
 | `actor` | string | Named threat actor if known |
 | `cve` | string | Associated CVE identifiers |
 
+Lookup CSV values arrive as the strings `"true"`/`"false"`, so `| where` (eval semantics) must compare against quoted strings; an unquoted `noise=true` in `where` reads `true` as a field name and matches nothing. Unquoted values are fine in the `search` command.
+
 ## Common enrichment patterns
 
 ### Noise filter: remove background scanners from a firewall investigation
@@ -113,7 +115,7 @@ index=firewall sourcetype=cisco:asa action=blocked earliest=-24h
 | where isnotnull(src) AND match(src, "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 | stats count by src
 | lookup greynoise_full ip AS src OUTPUT noise, classification, tags
-| where noise=false AND classification!="benign"
+| where (isnull(noise) OR noise="false") AND (isnull(classification) OR classification!="benign")
 | sort - count
 | table src, count, classification, tags
 ```
@@ -139,7 +141,7 @@ index=proxy sourcetype=bluecoat:proxysg:access:kv earliest=-24h
 | where isnotnull(dest) AND match(dest, "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 | stats count by dest
 | lookup greynoise_riot ip AS dest OUTPUT riot, name AS riot_service
-| where riot=true
+| where riot="true"
 | stats sum(count) AS total_hits by riot_service
 | sort - total_hits
 ```
@@ -160,7 +162,7 @@ index=firewall sourcetype=cisco:asa action=permitted earliest=-24h
 | where isnotnull(src) AND match(src, "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 | stats count by src
 | lookup greynoise_full ip AS src OUTPUT classification, noise, riot, tags, actor, last_seen
-| where classification="malicious" OR (noise=true AND riot=false)
+| where classification="malicious" OR (noise="true" AND riot="false")
 | table src, count, classification, noise, tags, actor, last_seen
 ```
 
@@ -174,7 +176,7 @@ index IN (firewall, proxy, endpoint) earliest=-24h
 | where isnotnull(ip_field) AND match(ip_field, "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 | stats count by ip_field, index, sourcetype
 | lookup greynoise_full ip AS ip_field OUTPUT classification, noise, riot, tags, actor
-| where classification="malicious" OR noise=true
+| where classification="malicious" OR noise="true"
 | sort - count
 | table ip_field, count, classification, noise, tags, actor, index
 ```

--- a/splunk-enrichment-query-builder/references/multi-index-patterns.md
+++ b/splunk-enrichment-query-builder/references/multi-index-patterns.md
@@ -51,8 +51,8 @@ When indexes feed different add-ons with different field names, filter per-index
 ```spl
 ((index=firewall sourcetype=cisco:asa) OR (index=proxy sourcetype=bluecoat:proxysg:access:kv) OR (index=dns sourcetype=cisco:umbrella:dns))
 earliest=-24h
-| eval common_src=coalesce(src, src_ip, ClientIP)
-| eval common_dest=coalesce(dest, dest_ip, url)
+| eval common_src=coalesce(src, src_ip)
+| eval common_dest=coalesce(dest, dest_ip, url, query)
 | stats count by common_src, common_dest, sourcetype
 ```
 

--- a/splunk-enrichment-query-builder/references/splunk-cloud-index-management.md
+++ b/splunk-enrichment-query-builder/references/splunk-cloud-index-management.md
@@ -79,7 +79,7 @@ List only enabled event indexes sorted by event volume:
 
 ```spl
 | rest /services/data/indexes splunk_server=local
-| where datatype="event" AND disabled=0
+| where datatype="event" AND disabled="0"
 | table title, totalEventCount, frozenTimePeriodInSecs, maxTotalDataSizeMB
 | sort - totalEventCount
 ```
@@ -116,17 +116,17 @@ If a query must target `_internal` (for audit or performance investigation), use
 
 ## Federated search
 
-Federated search allows a Splunk Cloud deployment to query an external Splunk Enterprise environment or a second Splunk Cloud stack as a remote peer:
+Federated search allows a Splunk Cloud deployment to query an external Splunk Enterprise environment or a second Splunk Cloud stack as a remote peer. In standard mode, address the remote index by prefixing its name with `federated:`:
 
 ```spl
-| federated index=remote_firewall sourcetype=cisco:asa earliest=-24h
+index=federated:remote_firewall sourcetype=cisco:asa earliest=-24h
 | stats count by src, dest
 ```
 
 Prerequisites:
-- A federated provider configured under Settings > Federated Search.
+- A federated provider configured under Settings > Federated Search, with a federated index defined that maps to the remote index.
 - Network connectivity and mutual trust between the environments.
-- The `federated` keyword replaces the standard `index=` prefix in the search.
+- The `federated:` prefix is applied to the index name itself (`index=federated:<name>`); the search otherwise uses standard syntax.
 
 ## Creating an index (Victoria, self-service)
 

--- a/splunk-sentinel-query-builder/SKILL.md
+++ b/splunk-sentinel-query-builder/SKILL.md
@@ -40,9 +40,10 @@ Expect these inputs when available:
 
 Return one of these:
 
-- `query`: quick hunt or triage query
+- `query`: quick hunt, triage, or dashboard-panel query
 - `detection`: query plus threshold and tuning notes
 - `translation`: SPL to KQL or KQL to SPL
+- `optimization`: rewritten query plus what changed and why it is faster
 - `discovery`: checklist plus starter query when schema is missing
 
 Default response shape:
@@ -71,7 +72,7 @@ Do not let lower-priority hints override higher-priority schema facts.
 ## Core workflow
 
 1. Identify platform: `splunk`, `sentinel`, or `both`.
-2. Identify task: hunt, detection, triage, dashboard, or translation.
+2. Identify task: hunt, detection, triage, dashboard, translation, or optimization.
 3. Prefer the internal data dictionary if the user provides a URL or excerpt.
 4. Constrain time and dataset first.
 5. Filter early, parse late, aggregate late.


### PR DESCRIPTION
## Summary

Two commits: the original PowerShell single-element array unwrap fix, plus fixes for 17 findings from a fresh full-repository review (4 parallel reviewer passes over the validator, the Python builder, the SPL references, and cross-file consistency — every finding verified before fixing).

### Validator (`scripts/validate-skill-pack.ps1`)
- **Single-element array unwrap** (original fix): `@(@("a","b"))` flattens, so `$helperPair[0]` returned `"s"` → `Cannot find path '...\s'` in CI
- **`Get-YamlList` never found the first key of any section**: `:\s*` greedily ate the newline *and* the first child line's indent, so `^\s{2}` never matched it; the first list item of matched keys was likewise dropped. With the empty-empty strictness check this would have failed CI spuriously on valid files. Fixed with `:[ \t]*\r?\n`
- Missing/empty files no longer crash the run mid-report; case-sensitive comparisons for drift/key checks

### CI (`.github/workflows/validate.yml`)
- Python compile step now runs with `if: !cancelled()` so a validation failure can't mask a Python syntax error

### Python (`build_splunk_dictionary.py`)
- Oneshot searches now pass `count=0` — the endpoint's default 100-row cap silently truncated sourcetype discovery and CIM coverage on any real deployment
- `_redact_url_credentials` fails closed (unparseable URL → placeholder, never the original credential-bearing string)
- `_safe_spl_ident` uses `fullmatch` (the `$` anchor accepted a trailing newline)
- ERROR/FATAL messages inside HTTP-200 search responses surface as warnings instead of reading as "no data"
- String boolean normalization for `disabled`/`enabled` REST flags; non-JSON 200 responses get a clear error; up-front credential/arg validation

### SPL references
- **GreyNoise**: all `| where noise=true`-style comparisons quoted — under eval semantics an unquoted `true` is a *field reference*, so every such filter matched nothing; noise filter made null-tolerant so IPs absent from the lookup are kept; lookup-definition naming documented
- **Splunk Cloud**: `| federated ...` replaced with the real `index=federated:<name>` syntax; `disabled="0"` quoted
- **Multi-index**: coalesce example now uses fields its own sourcetypes emit

### Consistency
- Sentinel SKILL.md gains the promised `optimization` task + output shape; data-dictionary invocation prompt unified across openai/claude/codex helpers; enrichment `prompt_shape` gains `Environment`/`Data dictionary` lines; README/plan trees corrected; golden-prompt fixtures added for the two previously uncovered skills

## Test plan

- [x] `python3 -m py_compile` passes
- [x] Unit checks for `_safe_spl_ident`, `_redact_url_credentials`, `_content_flag`, `_collect_search_messages` pass
- [x] Python mirror of the fixed validator passes on the whole repo (all sections/keys/items now extracted; parity, key, and link checks green)
- [x] All modified files ASCII-clean
- [ ] CI (`Validate skill pack` on windows-latest) green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC