### PR TITLE
Fix 10 findings from the post-merge review of #20

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,19 +12,22 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
+        id: checkout
         uses: actions/checkout@v4
 
       - name: Run skill pack validation
         shell: pwsh
         run: ./scripts/validate-skill-pack.ps1
 
+      # Run even when validation fails so a validator issue cannot mask a
+      # Python syntax error, but only when checkout actually succeeded.
       - name: Set up Python
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Compile Python helpers
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         shell: pwsh
         run: python -m py_compile .\splunk-data-dictionary-builder\scripts\build_splunk_dictionary.py

--- a/scripts/validate-skill-pack.ps1
+++ b/scripts/validate-skill-pack.ps1
@@ -37,6 +37,11 @@ function Assert-Exists {
     }
 }
 
+function Test-RepoFile {
+    param([string]$RelativePath)
+    return Test-Path -LiteralPath (Get-RepoFile $RelativePath) -PathType Leaf
+}
+
 function Assert-Contains {
     param(
         [string]$RelativePath,
@@ -56,17 +61,21 @@ function Get-YamlList {
         [string]$Key
     )
 
-    # ':[ \t]*\r?\n' (not ':\s*') so the match stops at the line break and the
-    # child lines keep their indentation; '\s*' would swallow the first child's
-    # indent and the '^\s{2}' / '^\s{4}' anchors below would never match it.
-    $sectionPattern = "(?ms)^$([regex]::Escape($Section)):[ \t]*\r?\n(.*?)(?=^\S|\z)"
+    # The header match stops at the line break (not ':\s*') so the child lines
+    # keep their indentation; '\s*' would swallow the first child's indent and
+    # the '^\s{2}' / '^\s{4}' anchors below would never match it. An optional
+    # trailing '# comment' and end-of-file (for a header on the last line) are
+    # tolerated. Only block-style lists ('key:' then 4-space '- "item"' lines)
+    # are machine-checked; inline flow lists like 'key: []' are not supported.
+    $headerTail = "[ \t]*(?:#[^\r\n]*)?(?:\r?\n|\z)"
+    $sectionPattern = "(?ms)^$([regex]::Escape($Section)):$headerTail(.*?)(?=^\S|\z)"
     $sectionMatch = [regex]::Match($Text, $sectionPattern)
     if (-not $sectionMatch.Success) {
         return @()
     }
 
     $sectionBody = $sectionMatch.Groups[1].Value
-    $keyPattern = "(?ms)^\s{2}$([regex]::Escape($Key)):[ \t]*\r?\n(.*?)(?=^\s{2}\S|\z)"
+    $keyPattern = "(?ms)^\s{2}$([regex]::Escape($Key)):$headerTail(.*?)(?=^\s{2}\S|\z)"
     $keyMatch = [regex]::Match($sectionBody, $keyPattern)
     if (-not $keyMatch.Success) {
         return @()
@@ -147,6 +156,12 @@ foreach ($file in $trackedFiles) {
     if ($text -match '(?m)^(<<<<<<<|=======|>>>>>>>)') {
         Add-Issue "$file contains a conflict marker"
     }
+    # SPL 'where' uses eval semantics: an unquoted true/false is a field
+    # reference, so the comparison silently matches nothing. Enforce the
+    # quoting rule documented in greynoise-integration.md across all docs.
+    if ($file -like "*.md" -and $text -cmatch '(?m)^\s*\| where [^|\r\n]*=\s*(true|false)\b') {
+        Add-Issue "$file compares against unquoted true/false in an SPL where clause; quote the value (=`"true`")"
+    }
     foreach ($char in $text.ToCharArray()) {
         $code = [int][char]$char
         $allowed = ($code -eq 9) -or ($code -eq 10) -or ($code -eq 13) -or (($code -ge 32) -and ($code -le 126))
@@ -158,6 +173,11 @@ foreach ($file in $trackedFiles) {
 }
 
 foreach ($skill in @("splunk-sentinel-query-builder/SKILL.md", "splunk-data-dictionary-builder/SKILL.md", "splunk-enrichment-query-builder/SKILL.md")) {
+    # A missing file is already reported by Assert-Exists; content checks on it
+    # would only add misdirecting issues.
+    if (-not (Test-RepoFile $skill)) {
+        continue
+    }
     Assert-Contains $skill '(?s)^---\s+name:\s+[-a-z0-9]+\s+description:\s+.+?\s+---' "valid skill frontmatter"
     Assert-Contains $skill '## Important' "top-level Important section"
     Assert-Contains $skill '## Inputs' "Inputs section"
@@ -165,6 +185,9 @@ foreach ($skill in @("splunk-sentinel-query-builder/SKILL.md", "splunk-data-dict
 
 $requiredOpenaiKeys = @("interface:", "display_name:", "short_description:", "default_prompt:", "policy:", "allow_implicit_invocation: false")
 foreach ($skill in @("splunk-sentinel-query-builder", "splunk-data-dictionary-builder", "splunk-enrichment-query-builder")) {
+    if (-not (Test-RepoFile "$skill/agents/openai.yaml")) {
+        continue
+    }
     $skillOpenai = Read-Text "$skill/agents/openai.yaml"
     foreach ($key in $requiredOpenaiKeys) {
         if ($skillOpenai -cnotmatch [regex]::Escape($key)) {
@@ -179,6 +202,9 @@ foreach ($helperPair in @(
     @("splunk-sentinel-query-builder/agents/claude-opus.yaml", "splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml"),
     @("splunk-enrichment-query-builder/agents/claude-opus.yaml", "splunk-enrichment-query-builder/agents/codex-gpt-5.4.yaml")
 )) {
+    if (-not (Test-RepoFile $helperPair[0]) -or -not (Test-RepoFile $helperPair[1])) {
+        continue
+    }
     $claude = Read-Text $helperPair[0]
     $codex = Read-Text $helperPair[1]
     foreach ($section in @("prompt_shape", "default_sections", "short_sections", "token_rules", "truth_order", "stop_conditions")) {
@@ -195,10 +221,12 @@ foreach ($helperPair in @(
 }
 
 # Data-dictionary builder uses a simpler helper structure; check only the sections it defines.
-$claude = Read-Text "splunk-data-dictionary-builder/agents/claude-opus.yaml"
-$codex = Read-Text "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml"
-foreach ($section in @("token_rules", "stop_conditions")) {
-    Assert-ListsEqual "splunk-data-dictionary-builder helpers / $section" (Get-YamlList $claude "behavior" $section) (Get-YamlList $codex "behavior" $section)
+if ((Test-RepoFile "splunk-data-dictionary-builder/agents/claude-opus.yaml") -and (Test-RepoFile "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml")) {
+    $claude = Read-Text "splunk-data-dictionary-builder/agents/claude-opus.yaml"
+    $codex = Read-Text "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml"
+    foreach ($section in @("token_rules", "stop_conditions")) {
+        Assert-ListsEqual "splunk-data-dictionary-builder helpers / $section" (Get-YamlList $claude "behavior" $section) (Get-YamlList $codex "behavior" $section)
+    }
 }
 
 $dictionaryScript = Read-Text "splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py"

--- a/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
+++ b/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
@@ -22,12 +22,27 @@ from typing import Any
 # unquoted SPL token, so they are safe to allow.
 _SAFE_IDENT_RE = re.compile(r"[A-Za-z0-9_-]+")
 
+_CREDENTIALS_MESSAGE = "Provide SPLUNK_TOKEN or SPLUNK_USERNAME/SPLUNK_PASSWORD."
+
+_TRUTHY_STRINGS = {"1", "true", "yes", "on"}
+_FALSY_STRINGS = {"0", "false", "no", "off", ""}
+
+
+def parse_bool(value: str, default: bool) -> bool:
+    """Parse a boolean-ish string with one canonical truthy/falsy set; unknown values return default."""
+    normalized = value.strip().lower()
+    if normalized in _TRUTHY_STRINGS:
+        return True
+    if normalized in _FALSY_STRINGS:
+        return False
+    return default
+
 
 def env_bool(name: str, default: bool) -> bool:
     value = os.getenv(name)
     if value is None:
         return default
-    return value.strip().lower() not in {"0", "false", "no"}
+    return parse_bool(value, default)
 
 
 def parse_args() -> argparse.Namespace:
@@ -67,15 +82,18 @@ class SplunkClient:
             raw = f"{self.username}:{self.password}".encode("utf-8")
             request.add_header("Authorization", f"Basic {base64.b64encode(raw).decode('ascii')}")
         else:
-            raise ValueError("Provide SPLUNK_TOKEN or SPLUNK_USERNAME/SPLUNK_PASSWORD.")
+            # main() validates credentials up front; this guards direct library use.
+            raise ValueError(_CREDENTIALS_MESSAGE)
         try:
             with urllib.request.urlopen(request, context=self.context, timeout=30) as response:
-                body = response.read().decode("utf-8")
+                raw = response.read()
             try:
+                body = raw.decode("utf-8")
                 return json.loads(body)
-            except ValueError as error:
+            except (UnicodeDecodeError, ValueError) as error:
+                preview = raw.decode("utf-8", errors="replace")[:200]
                 raise RuntimeError(
-                    f"Splunk returned non-JSON for {path} (is this the management port, usually 8089?): {body[:200]}"
+                    f"Splunk returned non-JSON for {path} (is this the management port, usually 8089?): {preview}"
                 ) from error
         except urllib.error.HTTPError as error:
             body = error.read().decode("utf-8", errors="replace")
@@ -127,9 +145,12 @@ def _redact_url_credentials(url: str) -> str:
         parsed = urllib.parse.urlparse(url)
         if not (parsed.username or parsed.password):
             return url
-        netloc = parsed.hostname or ""
-        if parsed.port:
-            netloc = f"{netloc}:{parsed.port}"
+        host = parsed.hostname or ""
+        if ":" in host:
+            # urlparse strips the brackets from IPv6 literals; restore them so
+            # the rebuilt netloc stays a valid URL.
+            host = f"[{host}]"
+        netloc = f"{host}:{parsed.port}" if parsed.port else host
         return urllib.parse.urlunparse(parsed._replace(netloc=netloc))
     except Exception:
         # Redaction must fail closed: an unparseable URL may still carry
@@ -140,7 +161,7 @@ def _redact_url_credentials(url: str) -> str:
 def _content_flag(value: Any) -> bool:
     """Normalize a REST content boolean that may arrive as bool, int, or the strings '0'/'1'/'true'/'false'."""
     if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes"}
+        return parse_bool(value, False)
     return bool(value)
 
 
@@ -301,7 +322,10 @@ def discover_sourcetypes(client: SplunkClient, indexes: list[str], earliest: str
     if not indexes:
         return []
     index_filter = " OR ".join(f"index={spl_quote(index)}" for index in indexes)
-    search = f"| tstats count where ({index_filter}) by index, sourcetype"
+    # Sort by volume so the full inventory is ordered and the
+    # [:max_sourcetypes] sampling slice takes the highest-volume sourcetypes
+    # rather than tstats group-by order.
+    search = f"| tstats count where ({index_filter}) by index, sourcetype | sort 0 - count"
     try:
         payload = client.search_oneshot(search, earliest)
     except RuntimeError as error:
@@ -346,7 +370,7 @@ def main() -> int:
         print("Missing --base-url or SPLUNK_BASE_URL.", file=sys.stderr)
         return 2
     if not args.token and not (args.username and args.password):
-        print("Missing credentials: provide SPLUNK_TOKEN or SPLUNK_USERNAME/SPLUNK_PASSWORD.", file=sys.stderr)
+        print(_CREDENTIALS_MESSAGE, file=sys.stderr)
         return 2
     if args.sample_size < 1:
         print("--sample-size must be at least 1.", file=sys.stderr)

--- a/splunk-enrichment-query-builder/references/greynoise-integration.md
+++ b/splunk-enrichment-query-builder/references/greynoise-integration.md
@@ -115,7 +115,7 @@ index=firewall sourcetype=cisco:asa action=blocked earliest=-24h
 | where isnotnull(src) AND match(src, "^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 | stats count by src
 | lookup greynoise_full ip AS src OUTPUT noise, classification, tags
-| where (isnull(noise) OR noise="false") AND (isnull(classification) OR classification!="benign")
+| where coalesce(noise, "")!="true" AND coalesce(classification, "")!="benign"
 | sort - count
 | table src, count, classification, tags
 ```

--- a/splunk-sentinel-query-builder/agents/claude-opus.yaml
+++ b/splunk-sentinel-query-builder/agents/claude-opus.yaml
@@ -16,7 +16,7 @@ skill_requirements:
     - "Provide examples and troubleshooting through progressive disclosure."
 
 invocation:
-  preferred_prompt: "Use $splunk-sentinel-query-builder to return the smallest useful result for my Splunk or Sentinel task: query, detection, translation, or discovery. Use my exact schema when provided, and switch to discovery mode instead of guessing when datasets are unclear."
+  preferred_prompt: "Use $splunk-sentinel-query-builder to return the smallest useful result for my Splunk or Sentinel task: query, detection, translation, optimization, or discovery. Use my exact schema when provided, and switch to discovery mode instead of guessing when datasets are unclear."
   prompt_shape:
     - "Platform: Splunk | Sentinel | Both"
     - "Task: hunt | detection | triage | dashboard | translation | optimization"

--- a/splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml
+++ b/splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml
@@ -16,7 +16,7 @@ skill_requirements:
     - "Provide examples and troubleshooting through progressive disclosure."
 
 invocation:
-  preferred_prompt: "Use $splunk-sentinel-query-builder to return the smallest useful result for my Splunk or Sentinel task: query, detection, translation, or discovery. Use my exact schema when provided, and switch to discovery mode instead of guessing when datasets are unclear."
+  preferred_prompt: "Use $splunk-sentinel-query-builder to return the smallest useful result for my Splunk or Sentinel task: query, detection, translation, optimization, or discovery. Use my exact schema when provided, and switch to discovery mode instead of guessing when datasets are unclear."
   prompt_shape:
     - "Platform: Splunk | Sentinel | Both"
     - "Task: hunt | detection | triage | dashboard | translation | optimization"

--- a/splunk-sentinel-query-builder/agents/openai.yaml
+++ b/splunk-sentinel-query-builder/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "SIEM Query Builder"
   short_description: "Build Splunk SPL and Sentinel KQL from real schema context"
-  default_prompt: "Use $splunk-sentinel-query-builder to return the smallest useful result for my Splunk or Sentinel task: query, detection, translation, or discovery. Use my exact schema when provided, and switch to discovery mode instead of guessing when datasets are unclear."
+  default_prompt: "Use $splunk-sentinel-query-builder to return the smallest useful result for my Splunk or Sentinel task: query, detection, translation, optimization, or discovery. Use my exact schema when provided, and switch to discovery mode instead of guessing when datasets are unclear."
 
 policy:
   allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

Fixes all 10 findings from the `/code-review` of the PR #20 squash (8 finder angles → verified by 2 adversarial verifiers; 2 additional candidates were refuted during verification and intentionally not changed).

### Correctness
- **Uncaught `UnicodeDecodeError`** (`build_splunk_dictionary.py`): the HTTP 200 body is now decoded inside the handled `try`, so a non-UTF-8 response (wrong port, proxy page) raises the friendly "is this the management port?" `RuntimeError` instead of a raw traceback that crashes the whole run
- **IPv6 URL corruption** (`_redact_url_credentials`): `urlparse.hostname` strips IPv6 brackets; they're restored when rebuilding the netloc, so `https://user:pw@[2001:db8::1]:8089` now redacts to `https://[2001:db8::1]:8089` instead of the invalid `https://2001:db8::1:8089`
- **Arbitrary-order sampling** (`discover_sourcetypes`): added `| sort 0 - count` so the inventory is volume-ordered and the `--max-sourcetypes` slice samples the highest-volume sourcetypes, not tstats group-by order
- **Blank-cell noise filter** (`greynoise-integration.md`): `isnull()` misses matched lookup rows with empty CSV cells; the filter now uses `coalesce(noise, "")!="true"`

### Validator robustness
- `Get-YamlList` headers tolerate trailing `# comments` and EOF-without-newline (previously spurious "Helper drift" failures on valid YAML); inline flow lists documented as unsupported
- Missing files are reported once by `Assert-Exists`; content checks now skip them instead of piling 7+ misdirecting issues on one root cause
- New mechanical check flags `| where x=true/false` in markdown SPL examples — the eval-semantics bug class fixed in #20 can no longer recur silently (line-anchored so the prose documenting the rule is exempt)

### CI + consistency
- Python steps now gate on `steps.checkout.outcome == 'success'` in addition to `!cancelled()` — a failed checkout no longer runs `py_compile` in an empty workspace
- Sentinel skill's three invocation prompts now include `optimization`, matching SKILL.md and `prompt_shape`
- `env_bool`/`_content_flag` unified on one `parse_bool` with a canonical truthy/falsy set (previously opposite polarities: `"on"` → True via one, False via the other); shared credentials message between `main()` preflight and `request()`

## Test plan

- [x] `python3 -m py_compile` passes
- [x] Unit checks: IPv6/hostname/port redaction, `parse_bool`/`env_bool`/`_content_flag` polarity, decode-inside-try structure, sort clause present
- [x] Python mirror of new validator regexes: all real helper files parse identically; inline-comment and EOF variants now parse; where-boolean scan has zero matches repo-wide, catches the bug form, exempts the prose rule
- [x] All modified files ASCII-clean
- [ ] `Validate skill pack` workflow (blocked: repo Actions not creating runs since June 30 — see prior PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC

---
_Generated by [Claude Code](https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC)_