### PR TITLE
Clear all deferred review findings: validator traps, dedup, CI job split

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,27 +7,29 @@ on:
     branches:
       - main
 
+# Separate jobs so a validator failure and a Python syntax error each get an
+# independent status check, and neither can mask the other.
 jobs:
   validate:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        id: checkout
         uses: actions/checkout@v4
 
       - name: Run skill pack validation
         shell: pwsh
         run: ./scripts/validate-skill-pack.ps1
 
-      # Run even when validation fails so a validator issue cannot mask a
-      # Python syntax error, but only when checkout actually succeeded.
+  py-compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Set up Python
-        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Compile Python helpers
-        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
-        shell: pwsh
-        run: python -m py_compile .\splunk-data-dictionary-builder\scripts\build_splunk_dictionary.py
+        run: python -m py_compile splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py

--- a/scripts/validate-skill-pack.ps1
+++ b/scripts/validate-skill-pack.ps1
@@ -267,7 +267,7 @@ foreach ($skill in @("splunk-sentinel-query-builder", "splunk-data-dictionary-bu
         }
     }
     if (($prompts.Values | Select-Object -Unique).Count -gt 1) {
-        Add-Issue "Invocation prompt drift in $skill: openai default_prompt and helper preferred_prompt values differ"
+        Add-Issue "Invocation prompt drift in ${skill}: openai default_prompt and helper preferred_prompt values differ"
     }
 }
 

--- a/scripts/validate-skill-pack.ps1
+++ b/scripts/validate-skill-pack.ps1
@@ -15,18 +15,24 @@ function Get-RepoFile {
     return Join-Path $Root $RelativePath
 }
 
+$script:textCache = @{}
+
 function Read-Text {
     param([string]$RelativePath)
+    if ($script:textCache.ContainsKey($RelativePath)) {
+        return $script:textCache[$RelativePath]
+    }
     $path = Get-RepoFile $RelativePath
-    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+    $text = ""
+    if (Test-Path -LiteralPath $path -PathType Leaf) {
         # Assert-Exists reports missing required files; returning empty text
         # lets the run finish and print every collected issue.
-        return ""
+        $raw = Get-Content -Raw -Path $path
+        if ($null -ne $raw) {
+            $text = $raw
+        }
     }
-    $text = Get-Content -Raw -Path $path
-    if ($null -eq $text) {
-        return ""
-    }
+    $script:textCache[$RelativePath] = $text
     return $text
 }
 
@@ -143,7 +149,9 @@ foreach ($file in $requiredFiles) {
     Assert-Exists $file
 }
 
-$trackedFiles = git -C $Root ls-files
+# quotepath=false emits non-ASCII filenames raw instead of C-quoted octal,
+# which would fail Test-Path and silently skip those files from validation.
+$trackedFiles = git -C $Root -c core.quotepath=false ls-files
 foreach ($file in $trackedFiles) {
     $path = Get-RepoFile $file
     if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
@@ -153,7 +161,10 @@ foreach ($file in $trackedFiles) {
     if ($null -eq $text) {
         continue
     }
-    if ($text -match '(?m)^(<<<<<<<|=======|>>>>>>>)') {
+    # Git conflict markers are exactly seven chars followed by a space+label
+    # (<<<<<<< / >>>>>>>) or alone on the line (=======); the right-side anchor
+    # avoids flagging setext heading underlines of eight or more equals signs.
+    if ($text -match '(?m)^(<{7}( |$)|={7}$|>{7}( |$))') {
         Add-Issue "$file contains a conflict marker"
     }
     # SPL 'where' uses eval semantics: an unquoted true/false is a field
@@ -196,36 +207,67 @@ foreach ($skill in @("splunk-sentinel-query-builder", "splunk-data-dictionary-bu
     }
 }
 
-# Query-builder skills (sentinel, enrichment) use a structured response contract;
-# check that both helper files carry the same sections.
-foreach ($helperPair in @(
-    @("splunk-sentinel-query-builder/agents/claude-opus.yaml", "splunk-sentinel-query-builder/agents/codex-gpt-5.4.yaml"),
-    @("splunk-enrichment-query-builder/agents/claude-opus.yaml", "splunk-enrichment-query-builder/agents/codex-gpt-5.4.yaml")
-)) {
-    if (-not (Test-RepoFile $helperPair[0]) -or -not (Test-RepoFile $helperPair[1])) {
+# Helper pair parity: both companion files in a skill must carry the same
+# section lists. Query-builder skills use the full structured contract and
+# require the model-specific tuning sections; the data-dictionary builder
+# uses a simpler helper shape.
+$sectionParents = @{
+    prompt_shape     = "invocation"
+    default_sections = "response_contract"
+    short_sections   = "response_contract"
+    token_rules      = "behavior"
+    truth_order      = "behavior"
+    stop_conditions  = "behavior"
+}
+$helperChecks = @(
+    @{ Skill = "splunk-sentinel-query-builder";   Sections = @("prompt_shape", "default_sections", "short_sections", "token_rules", "truth_order", "stop_conditions"); RequireTuningSections = $true },
+    @{ Skill = "splunk-enrichment-query-builder"; Sections = @("prompt_shape", "default_sections", "short_sections", "token_rules", "truth_order", "stop_conditions"); RequireTuningSections = $true },
+    @{ Skill = "splunk-data-dictionary-builder";  Sections = @("token_rules", "stop_conditions"); RequireTuningSections = $false }
+)
+foreach ($check in $helperChecks) {
+    $claudePath = "$($check.Skill)/agents/claude-opus.yaml"
+    $codexPath = "$($check.Skill)/agents/codex-gpt-5.4.yaml"
+    if (-not (Test-RepoFile $claudePath) -or -not (Test-RepoFile $codexPath)) {
         continue
     }
-    $claude = Read-Text $helperPair[0]
-    $codex = Read-Text $helperPair[1]
-    foreach ($section in @("prompt_shape", "default_sections", "short_sections", "token_rules", "truth_order", "stop_conditions")) {
-        $parent = if ($section -in @("prompt_shape")) { "invocation" } elseif ($section -in @("default_sections", "short_sections")) { "response_contract" } else { "behavior" }
-        Assert-ListsEqual "$($helperPair[0]) / $section" (Get-YamlList $claude $parent $section) (Get-YamlList $codex $parent $section)
+    $claude = Read-Text $claudePath
+    $codex = Read-Text $codexPath
+    foreach ($section in $check.Sections) {
+        $parent = $sectionParents[$section]
+        Assert-ListsEqual "$claudePath / $section" (Get-YamlList $claude $parent $section) (Get-YamlList $codex $parent $section)
     }
-    # claude-opus helpers must carry trigger_tuning; codex helpers must carry packaging_rules.
-    if ($claude -cnotmatch 'trigger_tuning:') {
-        Add-Issue "$($helperPair[0]) is missing trigger_tuning section"
-    }
-    if ($codex -cnotmatch 'packaging_rules:') {
-        Add-Issue "$($helperPair[1]) is missing packaging_rules section"
+    if ($check.RequireTuningSections) {
+        # claude-opus helpers must carry trigger_tuning; codex helpers must carry packaging_rules.
+        if ($claude -cnotmatch 'trigger_tuning:') {
+            Add-Issue "$claudePath is missing trigger_tuning section"
+        }
+        if ($codex -cnotmatch 'packaging_rules:') {
+            Add-Issue "$codexPath is missing packaging_rules section"
+        }
     }
 }
 
-# Data-dictionary builder uses a simpler helper structure; check only the sections it defines.
-if ((Test-RepoFile "splunk-data-dictionary-builder/agents/claude-opus.yaml") -and (Test-RepoFile "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml")) {
-    $claude = Read-Text "splunk-data-dictionary-builder/agents/claude-opus.yaml"
-    $codex = Read-Text "splunk-data-dictionary-builder/agents/codex-gpt-5.4.yaml"
-    foreach ($section in @("token_rules", "stop_conditions")) {
-        Assert-ListsEqual "splunk-data-dictionary-builder helpers / $section" (Get-YamlList $claude "behavior" $section) (Get-YamlList $codex "behavior" $section)
+# The canonical invocation prompt is duplicated across openai.yaml and both
+# companion helpers; it has drifted before, so enforce three-way equality.
+foreach ($skill in @("splunk-sentinel-query-builder", "splunk-data-dictionary-builder", "splunk-enrichment-query-builder")) {
+    $prompts = @{}
+    foreach ($entry in @(
+        @{ Path = "$skill/agents/openai.yaml"; Key = "default_prompt" },
+        @{ Path = "$skill/agents/claude-opus.yaml"; Key = "preferred_prompt" },
+        @{ Path = "$skill/agents/codex-gpt-5.4.yaml"; Key = "preferred_prompt" }
+    )) {
+        if (-not (Test-RepoFile $entry.Path)) {
+            continue
+        }
+        $match = [regex]::Match((Read-Text $entry.Path), "(?m)^\s*$($entry.Key):\s*""(.*)""\s*$")
+        if ($match.Success) {
+            $prompts[$entry.Path] = $match.Groups[1].Value
+        } else {
+            Add-Issue "$($entry.Path) is missing a quoted $($entry.Key)"
+        }
+    }
+    if (($prompts.Values | Select-Object -Unique).Count -gt 1) {
+        Add-Issue "Invocation prompt drift in $skill: openai default_prompt and helper preferred_prompt values differ"
     }
 }
 
@@ -247,9 +289,16 @@ $markdownFiles = $trackedFiles | Where-Object { $_ -like "*.md" }
 $linkRegex = '\[[^\]]+\]\(([^)]+)\)'
 foreach ($file in $markdownFiles) {
     $text = Read-Text $file
+    # Fenced code blocks quote example markdown; links inside them are
+    # illustrations, not navigation, so strip the blocks before scanning.
+    $scanText = [regex]::Replace($text, '(?ms)^\s*```.*?^\s*```[ \t]*$', '')
     $baseDir = Split-Path -Parent (Get-RepoFile $file)
-    foreach ($match in [regex]::Matches($text, $linkRegex)) {
-        $target = $match.Groups[1].Value
+    foreach ($match in [regex]::Matches($scanText, $linkRegex)) {
+        $target = $match.Groups[1].Value.Trim()
+        # Normalize the CommonMark forms: <bracketed destination> and an
+        # optional quoted title after the destination.
+        $target = $target -replace '^\<(.*)\>$', '$1'
+        $target = ($target -replace '\s+"[^"]*"\s*$', '').Trim()
         if ($target -match '^(https?://|mailto:|#)') {
             continue
         }
@@ -257,6 +306,7 @@ foreach ($file in $markdownFiles) {
         if ([string]::IsNullOrWhiteSpace($targetPath)) {
             continue
         }
+        $targetPath = [uri]::UnescapeDataString($targetPath)
         $resolved = Join-Path $baseDir $targetPath
         if (-not (Test-Path -LiteralPath $resolved)) {
             Add-Issue "$file has broken local link: $target"

--- a/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
+++ b/splunk-data-dictionary-builder/scripts/build_splunk_dictionary.py
@@ -19,8 +19,9 @@ from typing import Any
 
 # fullmatch with no anchors: '$' would also match before a trailing newline.
 # Hyphens are permitted in Splunk dataset IDs and cannot break out of an
-# unquoted SPL token, so they are safe to allow.
-_SAFE_IDENT_RE = re.compile(r"[A-Za-z0-9_-]+")
+# unquoted SPL token, so they are safe to allow -- but not in the leading
+# position, where a bare '-' would read as a malformed option/negative value.
+_SAFE_IDENT_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_-]*")
 
 _CREDENTIALS_MESSAGE = "Provide SPLUNK_TOKEN or SPLUNK_USERNAME/SPLUNK_PASSWORD."
 
@@ -172,6 +173,17 @@ def _collect_search_messages(payload: dict[str, Any], context: str, warnings: li
             warnings.append(f"Splunk search message for {context}: {message.get('text', 'unknown error')}")
 
 
+def _run_search(client: SplunkClient, search: str, earliest: str, context: str, warnings: list[str]) -> dict[str, Any] | None:
+    """Run a oneshot search, recording failures and in-band error messages; None on failure."""
+    try:
+        payload = client.search_oneshot(search, earliest)
+    except RuntimeError as error:
+        warnings.append(str(error))
+        return None
+    _collect_search_messages(payload, context, warnings)
+    return payload
+
+
 # Sourcetype prefixes produced by common Splunkbase add-ons, mapped to the CIM
 # data models they are tagged for. These are offline fallback hints only;
 # cim_coverage (queried from the live instance) is the ground truth and also
@@ -276,12 +288,9 @@ def discover_cim_coverage(client: SplunkClient, datamodels: list[dict[str, Any]]
             if model_name is None or root_name is None:
                 continue
             search = f"| tstats {summaries}count from datamodel={model_name}.{root_name} by sourcetype"
-            try:
-                payload = client.search_oneshot(search, earliest)
-            except RuntimeError as error:
-                warnings.append(str(error))
+            payload = _run_search(client, search, earliest, f"cim_coverage {model_name}.{root_name}", warnings)
+            if payload is None:
                 continue
-            _collect_search_messages(payload, f"cim_coverage {model_name}.{root_name}", warnings)
             sourcetypes: dict[str, int] = {}
             for row in payload.get("results", []):
                 name = row.get("sourcetype")
@@ -326,24 +335,18 @@ def discover_sourcetypes(client: SplunkClient, indexes: list[str], earliest: str
     # [:max_sourcetypes] sampling slice takes the highest-volume sourcetypes
     # rather than tstats group-by order.
     search = f"| tstats count where ({index_filter}) by index, sourcetype | sort 0 - count"
-    try:
-        payload = client.search_oneshot(search, earliest)
-    except RuntimeError as error:
-        warnings.append(str(error))
+    payload = _run_search(client, search, earliest, "sourcetype discovery", warnings)
+    if payload is None:
         return []
-    _collect_search_messages(payload, "sourcetype discovery", warnings)
     return payload.get("results", [])
 
 
 def sample_fields(client: SplunkClient, index: str, sourcetype: str, earliest: str, sample_size: int, warnings: list[str]) -> dict[str, Any]:
     search = f"search index={spl_quote(index)} sourcetype={spl_quote(sourcetype)} | head {sample_size} | fields *"
-    try:
-        payload = client.search_oneshot(search, earliest)
-    except RuntimeError as error:
-        warnings.append(str(error))
+    payload = _run_search(client, search, earliest, f"field sampling {index}/{sourcetype}", warnings)
+    if payload is None:
         return {"index": index, "sourcetype": sourcetype, "fields": {}, "sample_count": 0}
 
-    _collect_search_messages(payload, f"field sampling {index}/{sourcetype}", warnings)
     fields: dict[str, dict[str, Any]] = {}
     results = payload.get("results", [])
     for event in results:

--- a/splunk-enrichment-query-builder/references/greynoise-integration.md
+++ b/splunk-enrichment-query-builder/references/greynoise-integration.md
@@ -199,4 +199,5 @@ Custom dashboard base queries:
 - RIOT covers major cloud and CDN ranges but not every benign IP. Absence from RIOT does not imply the IP is malicious.
 - `noise=true` means the IP sends unsolicited traffic to the public internet, not necessarily that it targeted your environment.
 - `gnenrich` consumes API quota. Use the scheduled lookup files for high-volume or recurring searches.
+- The quoted-string comparisons in this file are verified against the CSV lookups; `gnenrich` output typing and casing may differ by app version, so spot-check with `| stats values(noise)` before reusing a `where` filter on command output.
 - Lookup file freshness depends on the sync schedule configured in the app. Use `gnenrich` when real-time accuracy matters.


### PR DESCRIPTION
## Summary

Clears every finding deferred or cut from the two review rounds — nothing is left on the backlog after this.

### Validator latent traps (previously deferred)
- **Link checker**: strips fenced code blocks before scanning (a doc quoting an example markdown link no longer breaks CI) and normalizes CommonMark forms — `<bracketed>` destinations, trailing `"titles"`, percent-encoded paths
- **Conflict-marker regex**: right-side anchor added; a setext heading underline of 8+ `=` no longer false-positives
- **Non-ASCII filenames**: `git ls-files` runs with `core.quotepath=false` so such files are validated instead of silently skipped

### Cleanup findings (cut from the last review's top-10)
- Helper-pair parity is one data-driven table (pair + sections + tuning flag) with a static section→parent map — no more hand-rolled data-dictionary special case or per-iteration ternary chain
- New three-way invocation-prompt alignment check (`openai default_prompt` == both helper `preferred_prompt`s per skill) — this scalar drifted once before and list-parity checks can't see it
- `Read-Text` caches contents (was ~69 file opens for 32 files)
- Python: `_run_search` collapses the 3× try/except/collect-messages boilerplate; `_SAFE_IDENT_RE` requires a leading word character so `-name` gets the clean skip-warning path
- GreyNoise doc: caveat that `gnenrich` output typing is unverified vs the CSV lookups (the PLAUSIBLE finding)

### CI
- Workflow split into independent `validate` (windows/pwsh) and `py-compile` (ubuntu) jobs — independent status checks, no masking, no step-level `if:` conditions to maintain

## Test plan

- [x] `python3 -m py_compile` passes; unit checks for `_safe_spl_ident` (leading hyphen rejected) and `_run_search` (error → None + warning, success → messages collected)
- [x] Python mirror of ALL validator checks (helper table, prompt alignment, fence-stripped links, anchored conflict regex, where-boolean scan) passes repo-wide; new conflict regex still catches real markers
- [x] Workflow YAML parses; all modified files ASCII-clean
- [ ] `Validate skill pack` workflow (blocked: repo Actions outage since June 30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC

---
_Generated by [Claude Code](https://claude.ai/code/session_012w5pM383QBoysfdP4DNyHC)_